### PR TITLE
Pin dask-ml for dask-expr compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "rioxarray",
     "rasterio",
     "dask[diagnostics,dataframe]",
-    "dask-ml",
+    "dask-ml>=2024.3.20",
     "scikit-learn",
     "scikit-learn-knn-regression @ git+https://github.com/lemma-osu/scikit-learn-knn-regression",
 ]


### PR DESCRIPTION
@grovduck I'm not 100% sure we'll end up using `dask-ml` at all, but I figured I'd get this in place to avoid surprises down the line, since having the wrong `dask-ml` breaks the Gist example.

### Details
There's an incompatibility between dask-ml<2024.3.20 and dask>=2024.3.0 due to the new [dask-expr optimization](https://github.com/dask/dask/issues/10995). This pins dask-ml for backwards compatibility.

See https://github.com/dask/dask-ml/issues/983

EDIT: CI is failing because there are no tests to run :man_facepalming: 