### PR TITLE
Fix dataset pickling

### DIFF
--- a/src/sknnr_spatial/datasets/_base.py
+++ b/src/sknnr_spatial/datasets/_base.py
@@ -19,10 +19,13 @@ def _load_rasters_to_dataset(
     """Load a list of rasters from the data module as an xarray Dataset."""
     das = []
     for file_name, var_name in zip(file_names, var_names):
-        with resources.files(module_name).joinpath(file_name).open("rb") as bin:
-            da = rioxarray.open_rasterio(bin, chunks=chunks)
+        path = resources.files(module_name).joinpath(file_name)
+        da = (
+            rioxarray.open_rasterio(path, chunks=chunks)
+            .to_dataset(dim="band")
+            .rename({1: var_name})
+        )
 
-        da = da.to_dataset(dim="band").rename({1: var_name})
         das.append(da)
 
     return xr.merge(das)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,3 +1,4 @@
+import pickle
 from dataclasses import dataclass
 
 import pytest
@@ -36,6 +37,10 @@ def test_load_dataset(configuration: DatasetConfiguration, as_dataset: bool):
     assert y.shape == (configuration.n_samples, configuration.n_targets)
 
     if as_dataset:
+        # Some Dask schedulers require pickling, so ensure that the loaded dataset is
+        # pickleable during compute. We could try computing directly, but that is much
+        # slower.
+        assert pickle.dumps(X_image)
         assert list(X.columns) == list(X_image.data_vars)
         assert X_image.sizes == {
             "y": configuration.image_size[0],


### PR DESCRIPTION
There was a bug in `_load_rasters_to_dataset` that caused `compute` to fail with any Dask scheduler that requires pickling (anything but threads) because the file buffer used in raster loading isn't pickleable. The easy fix is just to load the file path built by `resources` rather than the file buffer.

For testing, I'm just directly checking that the dataset is pickleable. A more thorough test would be to fully compute the dataset with each scheduler to avoid any other surprise incompatibilities, but that would lead to some very slow tests as well as some complexity around setup/teardown with a `LocalCluster` (see dask/distributed#3540).

@grovduck let me know what you think about the testing here, and whether we should just bite the bullet and add in `compute` tests.