### PR TITLE
Estimator wrapper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,3 +82,9 @@ isort.known-first-party = ["sknnr_spatial"]
 
 [tool.hatch.metadata]
 allow-direct-references = true
+
+[tool.coverage.report]
+exclude_also = [
+    # Ignore TYPE_CHECKING blocks
+    "if TYPE_CHECKING:"
+]

--- a/src/sknnr_spatial/__init__.py
+++ b/src/sknnr_spatial/__init__.py
@@ -1,4 +1,4 @@
-from .wrapper import wrap
+from .estimator import wrap
 
 __version__ = "0.1.0+dev"
 

--- a/src/sknnr_spatial/__init__.py
+++ b/src/sknnr_spatial/__init__.py
@@ -1,9 +1,8 @@
-from .image._base import kneighbors, predict
+from .wrapper import wrap
 
 __version__ = "0.1.0+dev"
 
 
 __all__ = [
-    "predict",
-    "kneighbors",
+    "wrap",
 ]

--- a/src/sknnr_spatial/estimator.py
+++ b/src/sknnr_spatial/estimator.py
@@ -9,8 +9,8 @@ from sklearn.base import clone
 from .types import EstimatorType
 from .utils.estimator import (
     AttrWrapper,
-    check_is_x_image,
     check_wrapper_implements,
+    image_or_fallback,
     is_fitted,
 )
 from .utils.image import get_image_wrapper
@@ -91,11 +91,13 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
             The training input samples.
-
         y : array-like of shape (n_samples,) or (n_samples, n_outputs)
             The target values (class labels in classification, real numbers in
             regression). Single-output targets of shape (n_samples, 1) will be squeezed
             to shape (n_samples,) to allow consistent prediction across all estimators.
+        **kwargs : dict
+            Additional keyword arguments passed to the estimator's fit method, e.g.
+            `sample_weight`.
 
         Returns
         -------
@@ -116,7 +118,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         return self
 
     @check_wrapper_implements
-    @check_is_x_image
+    @image_or_fallback
     def predict(
         self, X_image: ImageType, *, nodata_vals: NoDataType = None
     ) -> ImageType:
@@ -147,7 +149,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         return wrapper.predict(estimator=self)
 
     @check_wrapper_implements
-    @check_is_x_image
+    @image_or_fallback
     def kneighbors(
         self, X_image: ImageType, *, nodata_vals: NoDataType = None, **kneighbors_kwargs
     ) -> ImageType | tuple[ImageType, ImageType]:

--- a/src/sknnr_spatial/estimator.py
+++ b/src/sknnr_spatial/estimator.py
@@ -41,22 +41,20 @@ class _AttrWrapper:
 
 class SpatialEstimator(_AttrWrapper):
     def __init__(self, wrapped: BaseEstimator):
-        self._wrapped = self._reset_estimator(wrapped)
+        super().__init__(self._reset_estimator(wrapped))
 
     @staticmethod
     def _reset_estimator(estimator: BaseEstimator) -> BaseEstimator:
         """Take an estimator and reset and warn if it was previously fitted."""
-        try:
-            check_is_fitted(estimator)
+        if is_fitted(estimator):
             warn(
                 "Wrapping estimator that has already been fit. The estimator must be "
                 "fit again after wrapping.",
                 stacklevel=2,
             )
-
             return clone(estimator)
-        except NotFittedError:
-            return estimator
+
+        return estimator
 
     @_AttrWrapper.check_for_wrapped_method
     def fit(self, X, y=None, **kwargs) -> SpatialEstimator:
@@ -89,3 +87,11 @@ class SpatialEstimator(_AttrWrapper):
 
 def wrap(estimator: BaseEstimator) -> SpatialEstimator:
     return SpatialEstimator(estimator)
+
+
+def is_fitted(estimator: BaseEstimator) -> bool:
+    try:
+        check_is_fitted(estimator)
+        return True
+    except NotFittedError:
+        return False

--- a/src/sknnr_spatial/estimator.py
+++ b/src/sknnr_spatial/estimator.py
@@ -84,7 +84,24 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
 
     @check_wrapper_implements
     def fit(self, X, y=None, **kwargs) -> ImageEstimator[EstimatorType]:
-        """Fit the wrapped estimator and return the wrapper."""
+        """
+        Fit an estimator from a training set (X, y).
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            The training input samples.
+
+        y : array-like of shape (n_samples,) or (n_samples, n_outputs)
+            The target values (class labels in classification, real numbers in
+            regression). Single-output targets of shape (n_samples, 1) will be squeezed
+            to shape (n_samples,) to allow consistent prediction across all estimators.
+
+        Returns
+        -------
+        self : ImageEstimator
+            The wrapper around the fitted estimator.
+        """
         # Squeeze extra y dimensions. This will convert from shape (n_samples, 1) which
         # causes inconsistent output shapes with different sklearn estimators, to
         # (n_samples,), which has a consistent output shape.
@@ -103,6 +120,29 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
     def predict(
         self, X_image: ImageType, *, nodata_vals: NoDataType = None
     ) -> ImageType:
+        """
+        Predict target(s) for X_image.
+
+        Notes
+        -----
+        If X_image is not an image, the estimator's unmodified predict method will be
+        called instead.
+
+        Parameters
+        ----------
+        X_image : Numpy or Xarray image with 3 dimensions (y, x, band)
+            The input image. Features in the band dimension should correspond with the
+            features used to fit the estimator.
+        nodata_vals : float or sequence of floats, optional
+            NoData values to mask in the output image. A single value will be broadcast
+            to all bands while sequences of values will be assigned band-wise. If None,
+            values will be inferred if possible based on image metadata.
+
+        Returns
+        -------
+        y_image : Numpy or Xarray image with 3 dimensions (y, x, targets)
+            The predicted values.
+        """
         return predict(X_image, estimator=self, nodata_vals=nodata_vals)
 
     @check_wrapper_implements
@@ -110,6 +150,37 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
     def kneighbors(
         self, X_image: ImageType, *, nodata_vals: NoDataType = None, **kneighbors_kwargs
     ) -> ImageType | tuple[ImageType, ImageType]:
+        """
+        Find the K-neighbors of each pixel in an image.
+
+        Returns indices of and distances to the neighbors for each pixel.
+
+        Notes
+        -----
+        If X_image is not an image, the estimator's unmodified kneighbors method will be
+        called instead.
+
+        Parameters
+        ----------
+        X_image : Numpy or Xarray image with 3 dimensions (y, x, band)
+            The input image. Features in the band dimension should correspond with the
+            features used to fit the estimator.
+        nodata_vals : float or sequence of floats, optional
+            NoData values to mask in the output image. A single value will be broadcast
+            to all bands while sequences of values will be assigned band-wise. If None,
+            values will be inferred if possible based on image metadata.
+        **kneighbors_kwargs
+            Additional arguments passed to the estimator's kneighbors method, e.g.
+            `return_distance`.
+
+        Returns
+        -------
+        neigh_dist : Numpy or Xarray image with 3 dimensions (y, x, neighbor)
+            Array representing the lengths to points, only present if
+            return_distance=True.
+        neigh_ind : Numpy or Xarray image with 3 dimensions (y, x, neighbor)
+            Indices of the nearest points in the population matrix.
+        """
         return kneighbors(
             X_image, estimator=self, nodata_vals=nodata_vals, **kneighbors_kwargs
         )

--- a/src/sknnr_spatial/estimator.py
+++ b/src/sknnr_spatial/estimator.py
@@ -6,7 +6,6 @@ from warnings import warn
 
 from sklearn.base import clone
 
-from .image._base import kneighbors, predict
 from .types import EstimatorType
 from .utils.estimator import (
     AttrWrapper,
@@ -14,6 +13,7 @@ from .utils.estimator import (
     check_wrapper_implements,
     is_fitted,
 )
+from .utils.image import get_image_wrapper
 
 if TYPE_CHECKING:
     import numpy as np
@@ -143,7 +143,8 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         y_image : Numpy or Xarray image with 3 dimensions (y, x, targets)
             The predicted values.
         """
-        return predict(X_image, estimator=self, nodata_vals=nodata_vals)
+        wrapper = get_image_wrapper(X_image)(X_image, nodata_vals=nodata_vals)
+        return wrapper.predict(estimator=self)
 
     @check_wrapper_implements
     @check_is_x_image
@@ -181,9 +182,8 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         neigh_ind : Numpy or Xarray image with 3 dimensions (y, x, neighbor)
             Indices of the nearest points in the population matrix.
         """
-        return kneighbors(
-            X_image, estimator=self, nodata_vals=nodata_vals, **kneighbors_kwargs
-        )
+        wrapper = get_image_wrapper(X_image)(X_image, nodata_vals=nodata_vals)
+        return wrapper.kneighbors(estimator=self, **kneighbors_kwargs)
 
 
 def wrap(estimator: EstimatorType) -> ImageEstimator[EstimatorType]:

--- a/src/sknnr_spatial/estimator.py
+++ b/src/sknnr_spatial/estimator.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import Callable
+from typing import Callable, Generic
 from warnings import warn
 
 from sklearn.base import BaseEstimator, clone
 from sklearn.utils.validation import NotFittedError, check_is_fitted
 
 from .image._base import is_image_type, kneighbors, predict
+from .types import AnyType, EstimatorType
 
 
-class _AttrWrapper:
+class _AttrWrapper(Generic[AnyType]):
     """A transparent object wrapper that accesses a wrapped object's attributes."""
 
-    def __init__(self, wrapped):
+    _wrapped: AnyType
+
+    def __init__(self, wrapped: AnyType):
         self._wrapped = wrapped
 
     def __getattr__(self, name: str):
@@ -24,7 +27,7 @@ class _AttrWrapper:
         return self._wrapped.__dict__
 
     @staticmethod
-    def check_for_wrapped_method(func: Callable) -> Callable:
+    def _check_for_wrapped_method(func: Callable) -> Callable:
         """Check that the method is implemented by the caller's wrapped instance."""
 
         @wraps(func)
@@ -39,12 +42,24 @@ class _AttrWrapper:
         return wrapper
 
 
-class SpatialEstimator(_AttrWrapper):
-    def __init__(self, wrapped: BaseEstimator):
+class ImageEstimator(_AttrWrapper[EstimatorType]):
+    """
+    An sklearn-compatible estimator wrapper with overriden methods for image data.
+
+    Parameters
+    ----------
+    wrapped : BaseEstimator
+        An sklearn-compatible estimator to wrap with image methods. Fitted estimators
+        will be reset when wrapped and must be re-fit after wrapping.
+    """
+
+    _wrapped: EstimatorType
+
+    def __init__(self, wrapped: EstimatorType):
         super().__init__(self._reset_estimator(wrapped))
 
     @staticmethod
-    def _reset_estimator(estimator: BaseEstimator) -> BaseEstimator:
+    def _reset_estimator(estimator: EstimatorType) -> EstimatorType:
         """Take an estimator and reset and warn if it was previously fitted."""
         if is_fitted(estimator):
             warn(
@@ -56,23 +71,23 @@ class SpatialEstimator(_AttrWrapper):
 
         return estimator
 
-    @_AttrWrapper.check_for_wrapped_method
-    def fit(self, X, y=None, **kwargs) -> SpatialEstimator:
+    @_AttrWrapper._check_for_wrapped_method
+    def fit(self, X, y=None, **kwargs) -> ImageEstimator[EstimatorType]:
         """Fit the wrapped estimator and return the wrapper."""
         self._wrapped = self._wrapped.fit(X, y, **kwargs)
         # TODO: Store all needed metadata, e.g. n targets, target names, etc.
         # TODO: Override the builtin feature name warning somehow
         return self
 
-    @_AttrWrapper.check_for_wrapped_method
+    @_AttrWrapper._check_for_wrapped_method
     def predict(self, X):
         # Allow predicting with non-image data using the wrapped estimator
         if not is_image_type(X):
             return self._wrapped.predict(X)
 
-        return predict(X, estimator=self._wrapped)
+        return predict(X, estimator=self)
 
-    @_AttrWrapper.check_for_wrapped_method
+    @_AttrWrapper._check_for_wrapped_method
     def kneighbors(self, X, return_distance=True, **kwargs):
         # Allow kneighbors with non-image data using the wrapped estimator
         if not is_image_type(X):
@@ -80,16 +95,46 @@ class SpatialEstimator(_AttrWrapper):
                 X, return_distance=return_distance, **kwargs
             )
 
-        return kneighbors(
-            X, return_distance=return_distance, estimator=self._wrapped, **kwargs
-        )
+        return kneighbors(X, return_distance=return_distance, estimator=self, **kwargs)
 
 
-def wrap(estimator: BaseEstimator) -> SpatialEstimator:
-    return SpatialEstimator(estimator)
+def wrap(estimator: EstimatorType) -> ImageEstimator[EstimatorType]:
+    """
+    Wrap an sklearn-compatible estimator with overriden methods for image data.
+
+    Parameters
+    ----------
+    estimator : BaseEstimator
+        An sklearn-compatible estimator to wrap with image methods. Fitted estimators
+        will be reset when wrapped and must be re-fit after wrapping.
+
+    Returns
+    -------
+    ImageEstimator
+        An estimator with relevant methods overriden to work with image data, e.g.
+        `predict` and `kneighbors`. Methods will continue to work with non-image data
+        and non-overriden methods and attributes will be unchanged.
+
+    Examples
+    --------
+    Instantiate an estimator, wrap it, then fit as usual:
+
+    >>> from sklearn.neighbors import KNeighborsRegressor
+    >>> from sknnr_spatial.datasets import load_swo_ecoplot
+    >>> X_img, X, y = load_swo_ecoplot()
+    >>> est = wrap(KNeighborsRegressor(n_neighbors=3)).fit(X, y)
+
+    Use a wrapped estimator to predict from image data stored in Numpy or Xarray arrays:
+
+    >>> pred = est.predict(X_img)
+    >>> pred.shape
+    (128, 128, 25)
+    """
+    return ImageEstimator(estimator)
 
 
 def is_fitted(estimator: BaseEstimator) -> bool:
+    """Return whether an estimator is fitted or not."""
     try:
         check_is_fitted(estimator)
         return True

--- a/src/sknnr_spatial/estimator.py
+++ b/src/sknnr_spatial/estimator.py
@@ -21,7 +21,7 @@ class FittedMetadata:
     """Metadata from a fitted estimator."""
 
     n_targets: int
-    target_names: tuple[str, ...]
+    target_names: tuple[str | int, ...]
 
 
 class _AttrWrapper(Generic[AnyType]):
@@ -94,7 +94,7 @@ class ImageEstimator(_AttrWrapper[EstimatorType]):
 
     def _get_target_names(
         self, y: np.ndarray | pd.DataFrame | pd.Series
-    ) -> tuple[str, ...]:
+    ) -> tuple[str | int, ...]:
         """Get the target names used to fit the estimator, if available."""
         # Dataframe
         if hasattr(y, "columns"):
@@ -105,7 +105,7 @@ class ImageEstimator(_AttrWrapper[EstimatorType]):
             return tuple([y.name])
 
         # Default to sequential identifiers
-        return tuple([f"b{i}" for i in range(self._get_n_targets(y))])
+        return tuple(range(self._get_n_targets(y)))
 
     @_AttrWrapper._check_for_wrapped_method
     def fit(self, X, y=None, **kwargs) -> ImageEstimator[EstimatorType]:

--- a/src/sknnr_spatial/estimator.py
+++ b/src/sknnr_spatial/estimator.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
     import numpy as np
     import pandas as pd
 
+    from .types import ImageType, NoDataType
+
 
 @dataclass
 class FittedMetadata:
@@ -98,13 +100,19 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
 
     @check_wrapper_implements
     @check_is_x_image
-    def predict(self, X):
-        return predict(X, estimator=self)
+    def predict(
+        self, X_image: ImageType, *, nodata_vals: NoDataType = None
+    ) -> ImageType:
+        return predict(X_image, estimator=self, nodata_vals=nodata_vals)
 
     @check_wrapper_implements
     @check_is_x_image
-    def kneighbors(self, X, return_distance=True, **kwargs):
-        return kneighbors(X, return_distance=return_distance, estimator=self, **kwargs)
+    def kneighbors(
+        self, X_image: ImageType, *, nodata_vals: NoDataType = None, **kneighbors_kwargs
+    ) -> ImageType | tuple[ImageType, ImageType]:
+        return kneighbors(
+            X_image, estimator=self, nodata_vals=nodata_vals, **kneighbors_kwargs
+        )
 
 
 def wrap(estimator: EstimatorType) -> ImageEstimator[EstimatorType]:

--- a/src/sknnr_spatial/image/__init__.py
+++ b/src/sknnr_spatial/image/__init__.py
@@ -1,2 +1,0 @@
-# Modules must be imported to register their single dispatch methods
-from . import dataarray, dataset, ndarray  # noqa: F401

--- a/src/sknnr_spatial/image/_base.py
+++ b/src/sknnr_spatial/image/_base.py
@@ -12,7 +12,7 @@ from ..types import ImageType
 
 if TYPE_CHECKING:
     from sklearn.base import BaseEstimator
-    from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
+    from sklearn.neighbors._base import KNeighborsMixin
 
     from ..estimator import ImageEstimator
     from ..types import NoDataType
@@ -183,6 +183,6 @@ class ImageWrapper(ABC, Generic[ImageType]):
     def kneighbors(
         self,
         *,
-        estimator: ImageEstimator[KNeighborsRegressor | KNeighborsClassifier],
+        estimator: ImageEstimator[KNeighborsMixin],
         **kneighbors_kwargs,
     ) -> ImageType | tuple[ImageType, ImageType]: ...

--- a/src/sknnr_spatial/image/_base.py
+++ b/src/sknnr_spatial/image/_base.py
@@ -187,20 +187,13 @@ def kneighbors(
     raise NotImplementedError(msg)
 
 
-@singledispatch
-def is_image_type(_):
-    """Check if the given X data is an image."""
-    return False
-
-
-@is_image_type.register(np.ndarray)
-@is_image_type.register(xr.DataArray)
-def _is_image_type_array(X):
+def is_image_type(X: ImageType) -> bool:
     # Feature array images must have exactly 3 dimensions: (y, x, band) or (band, y, x)
-    return X.ndim == 3
+    if isinstance(X, (np.ndarray, xr.DataArray)):
+        return X.ndim == 3
 
-
-@is_image_type.register(xr.Dataset)
-def _is_image_type_dataset(X):
     # Feature Dataset images must have exactly 2 dimensions: (x, y)
-    return len(X.dims) == 2
+    if isinstance(X, xr.Dataset):
+        return len(X.dims) == 2
+
+    return False

--- a/src/sknnr_spatial/image/_base.py
+++ b/src/sknnr_spatial/image/_base.py
@@ -12,8 +12,9 @@ from numpy.typing import NDArray
 
 if TYPE_CHECKING:
     from sklearn.base import BaseEstimator
-    from sklearn.neighbors import KNeighborsRegressor
+    from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 
+    from ..estimator import ImageEstimator
     from ..types import ImageType
 
 
@@ -167,7 +168,7 @@ class ImagePreprocessor(ABC):
 def predict(
     X_image: ImageType,
     *,
-    estimator: BaseEstimator,
+    estimator: ImageEstimator[BaseEstimator],
     nodata_vals=None,
 ) -> None:
     msg = f"predict is not implemented for type `{X_image.__class__.__name__}`."
@@ -178,7 +179,7 @@ def predict(
 def kneighbors(
     X_image: ImageType,
     *,
-    estimator: KNeighborsRegressor,
+    estimator: ImageEstimator[KNeighborsRegressor | KNeighborsClassifier],
     nodata_vals=None,
     **kneighbors_kwargs,
 ) -> None:

--- a/src/sknnr_spatial/image/_base.py
+++ b/src/sknnr_spatial/image/_base.py
@@ -7,7 +7,6 @@ from types import ModuleType
 from typing import TYPE_CHECKING
 
 import numpy as np
-import xarray as xr
 from numpy.typing import NDArray
 
 if TYPE_CHECKING:
@@ -185,15 +184,3 @@ def kneighbors(
 ) -> None:
     msg = f"kneighbors is not implemented for type `{X_image.__class__.__name__}`."
     raise NotImplementedError(msg)
-
-
-def is_image_type(X: ImageType) -> bool:
-    # Feature array images must have exactly 3 dimensions: (y, x, band) or (band, y, x)
-    if isinstance(X, (np.ndarray, xr.DataArray)):
-        return X.ndim == 3
-
-    # Feature Dataset images must have exactly 2 dimensions: (x, y)
-    if isinstance(X, xr.Dataset):
-        return len(X.dims) == 2
-
-    return False

--- a/src/sknnr_spatial/image/_base.py
+++ b/src/sknnr_spatial/image/_base.py
@@ -7,6 +7,7 @@ from types import ModuleType
 from typing import TYPE_CHECKING
 
 import numpy as np
+import xarray as xr
 from numpy.typing import NDArray
 
 if TYPE_CHECKING:
@@ -183,3 +184,22 @@ def kneighbors(
 ) -> None:
     msg = f"kneighbors is not implemented for type `{X_image.__class__.__name__}`."
     raise NotImplementedError(msg)
+
+
+@singledispatch
+def is_image_type(_):
+    """Check if the given X data is an image."""
+    return False
+
+
+@is_image_type.register(np.ndarray)
+@is_image_type.register(xr.DataArray)
+def _is_image_type_array(X):
+    # Feature array images must have exactly 3 dimensions: (y, x, band) or (band, y, x)
+    return X.ndim == 3
+
+
+@is_image_type.register(xr.Dataset)
+def _is_image_type_dataset(X):
+    # Feature Dataset images must have exactly 2 dimensions: (x, y)
+    return len(X.dims) == 2

--- a/src/sknnr_spatial/image/_base.py
+++ b/src/sknnr_spatial/image/_base.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 
     from ..estimator import ImageEstimator
-    from ..types import ImageType
+    from ..types import ImageType, NoDataType
 
 
 class ImagePreprocessor(ABC):
@@ -69,7 +69,7 @@ class ImagePreprocessor(ABC):
     def __init__(
         self,
         image: ImageType,
-        nodata_vals: float | tuple[float] | NDArray | None = None,
+        nodata_vals: NoDataType = None,
         nan_fill: float | None = 0.0,
     ):
         self.image = image
@@ -116,9 +116,7 @@ class ImagePreprocessor(ABC):
         # Set the mask where any band contains NoData
         return mask.max(axis=self.flat_band_dim)
 
-    def _validate_nodata_vals(
-        self, nodata_vals: float | tuple[float] | NDArray | None
-    ) -> NDArray | None:
+    def _validate_nodata_vals(self, nodata_vals: NoDataType) -> NDArray | None:
         """
         Get an array of NoData values in the shape (bands,) based on user input.
 
@@ -168,7 +166,7 @@ def predict(
     X_image: ImageType,
     *,
     estimator: ImageEstimator[BaseEstimator],
-    nodata_vals=None,
+    nodata_vals: NoDataType = None,
 ) -> None:
     msg = f"predict is not implemented for type `{X_image.__class__.__name__}`."
     raise NotImplementedError(msg)
@@ -179,7 +177,7 @@ def kneighbors(
     X_image: ImageType,
     *,
     estimator: ImageEstimator[KNeighborsRegressor | KNeighborsClassifier],
-    nodata_vals=None,
+    nodata_vals: NoDataType = None,
     **kneighbors_kwargs,
 ) -> None:
     msg = f"kneighbors is not implemented for type `{X_image.__class__.__name__}`."

--- a/src/sknnr_spatial/image/_dask_backed.py
+++ b/src/sknnr_spatial/image/_dask_backed.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 
     from ..estimator import ImageEstimator
-    from ..types import DaskBackedType
+    from ..types import DaskBackedType, NoDataType
     from .dataarray import DataArrayPreprocessor
     from .dataset import DatasetPreprocessor
 
@@ -24,7 +24,7 @@ def predict_from_dask_backed_array(
     *,
     estimator: ImageEstimator[BaseEstimator],
     preprocessor_cls: type[DataArrayPreprocessor] | type[DatasetPreprocessor],
-    nodata_vals=None,
+    nodata_vals: NoDataType = None,
 ) -> DaskBackedType:
     """Generic predict wrapper for Dask-backed arrays."""
     check_is_fitted(estimator)
@@ -60,7 +60,7 @@ def kneighbors_from_dask_backed_array(
     *,
     estimator: ImageEstimator[KNeighborsRegressor | KNeighborsClassifier],
     preprocessor_cls: type[DataArrayPreprocessor] | type[DatasetPreprocessor],
-    nodata_vals=None,
+    nodata_vals: NoDataType = None,
     **kneighbors_kwargs,
 ) -> DaskBackedType:
     """Generic kneighbors wrapper for Dask-backed arrays."""

--- a/src/sknnr_spatial/image/_dask_backed.py
+++ b/src/sknnr_spatial/image/_dask_backed.py
@@ -5,94 +5,91 @@ from typing import TYPE_CHECKING
 import dask.array as da
 from sklearn.utils.validation import check_is_fitted
 
+from ..types import DaskBackedType
+from ._base import ImageWrapper
+
 if TYPE_CHECKING:
     from sklearn.base import BaseEstimator
     from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 
     from ..estimator import ImageEstimator
-    from ..types import DaskBackedType, NoDataType
     from .dataarray import DataArrayPreprocessor
     from .dataset import DatasetPreprocessor
 
 
-class TargetInferenceError(Exception):
-    """Raised when the number of targets cannot be inferred from an estimator."""
+class DaskBackedWrapper(ImageWrapper[DaskBackedType]):
+    """A wrapper around a Dask-backed image that provides sklearn methods."""
 
+    preprocessor_cls: type[DataArrayPreprocessor] | type[DatasetPreprocessor]
+    preprocessor: DataArrayPreprocessor | DatasetPreprocessor
 
-def predict_from_dask_backed_array(
-    X_image: DaskBackedType,
-    *,
-    estimator: ImageEstimator[BaseEstimator],
-    preprocessor_cls: type[DataArrayPreprocessor] | type[DatasetPreprocessor],
-    nodata_vals: NoDataType = None,
-) -> DaskBackedType:
-    """Generic predict wrapper for Dask-backed arrays."""
-    check_is_fitted(estimator)
-    preprocessor = preprocessor_cls(X_image, nodata_vals=nodata_vals)
-    meta = estimator._wrapped_meta
+    def predict(
+        self,
+        *,
+        estimator: ImageEstimator[BaseEstimator],
+    ) -> DaskBackedType:
+        """Generic predict wrapper for Dask-backed arrays."""
+        check_is_fitted(estimator)
+        meta = estimator._wrapped_meta
 
-    if single_output := meta.n_targets == 1:
-        signature = "(x)->()"
-        output_sizes = {}
-    else:
-        signature = "(x)->(y)"
-        output_sizes = {"y": meta.n_targets}
+        if single_output := meta.n_targets == 1:
+            signature = "(x)->()"
+            output_sizes = {}
+        else:
+            signature = "(x)->(y)"
+            output_sizes = {"y": meta.n_targets}
 
-    y_pred = da.apply_gufunc(
-        estimator._wrapped.predict,
-        signature,
-        preprocessor.flat,
-        axis=preprocessor.flat_band_dim,
-        output_dtypes=[float],
-        output_sizes=output_sizes,
-        allow_rechunk=True,
-    )
+        y_pred = da.apply_gufunc(
+            estimator._wrapped.predict,
+            signature,
+            self.preprocessor.flat,
+            axis=self.preprocessor.flat_band_dim,
+            output_dtypes=[float],
+            output_sizes=output_sizes,
+            allow_rechunk=True,
+        )
 
-    # Reshape from (n_samples,) to (n_samples, 1)
-    if single_output:
-        y_pred = y_pred.reshape(-1, 1)
+        # Reshape from (n_samples,) to (n_samples, 1)
+        if single_output:
+            y_pred = y_pred.reshape(-1, 1)
 
-    return preprocessor.unflatten(y_pred, var_names=list(meta.target_names))
+        return self.preprocessor.unflatten(y_pred, var_names=list(meta.target_names))
 
-
-def kneighbors_from_dask_backed_array(
-    X_image: DaskBackedType,
-    *,
-    estimator: ImageEstimator[KNeighborsRegressor | KNeighborsClassifier],
-    preprocessor_cls: type[DataArrayPreprocessor] | type[DatasetPreprocessor],
-    nodata_vals: NoDataType = None,
-    **kneighbors_kwargs,
-) -> DaskBackedType:
-    """Generic kneighbors wrapper for Dask-backed arrays."""
-    check_is_fitted(estimator)
-    preprocessor = preprocessor_cls(X_image, nodata_vals=nodata_vals)
-    return_distance = kneighbors_kwargs.pop("return_distance", True)
-
-    k = estimator.n_neighbors
-    var_names = [f"k{i + 1}" for i in range(k)]
-
-    # Set the expected gufunc output depending on whether distances will be included
-    signature = "(x)->(k)" if not return_distance else "(x)->(k),(k)"
-    output_dtypes: list[type] = [int] if not return_distance else [float, int]
-
-    result = da.apply_gufunc(
-        estimator._wrapped.kneighbors,
-        signature,
-        preprocessor.flat,
-        output_sizes={"k": k},
-        output_dtypes=output_dtypes,
-        axis=preprocessor.flat_band_dim,
-        allow_rechunk=True,
-        return_distance=return_distance,
+    def kneighbors(
+        self,
+        *,
+        estimator: ImageEstimator[KNeighborsRegressor | KNeighborsClassifier],
         **kneighbors_kwargs,
-    )
+    ) -> DaskBackedType | tuple[DaskBackedType, DaskBackedType]:
+        """Generic kneighbors wrapper for Dask-backed arrays."""
+        check_is_fitted(estimator)
+        return_distance = kneighbors_kwargs.pop("return_distance", True)
 
-    if return_distance:
-        dist, nn = result
+        k = estimator.n_neighbors
+        var_names = [f"k{i + 1}" for i in range(k)]
 
-        dist = preprocessor.unflatten(dist, var_names=var_names)
-        nn = preprocessor.unflatten(nn, var_names=var_names)
+        # Set the expected gufunc output depending on whether distances will be included
+        signature = "(x)->(k)" if not return_distance else "(x)->(k),(k)"
+        output_dtypes: list[type] = [int] if not return_distance else [float, int]
 
-        return dist, nn
+        result = da.apply_gufunc(
+            estimator._wrapped.kneighbors,
+            signature,
+            self.preprocessor.flat,
+            output_sizes={"k": k},
+            output_dtypes=output_dtypes,
+            axis=self.preprocessor.flat_band_dim,
+            allow_rechunk=True,
+            return_distance=return_distance,
+            **kneighbors_kwargs,
+        )
 
-    return preprocessor.unflatten(result, var_names=var_names)
+        if return_distance:
+            dist, nn = result
+
+            dist = self.preprocessor.unflatten(dist, var_names=var_names)
+            nn = self.preprocessor.unflatten(nn, var_names=var_names)
+
+            return dist, nn
+
+        return self.preprocessor.unflatten(result, var_names=var_names)

--- a/src/sknnr_spatial/image/_dask_backed.py
+++ b/src/sknnr_spatial/image/_dask_backed.py
@@ -10,7 +10,7 @@ from ._base import ImageWrapper
 
 if TYPE_CHECKING:
     from sklearn.base import BaseEstimator
-    from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
+    from sklearn.neighbors._base import KNeighborsMixin
 
     from ..estimator import ImageEstimator
     from .dataarray import DataArrayPreprocessor
@@ -58,11 +58,10 @@ class DaskBackedWrapper(ImageWrapper[DaskBackedType]):
     def kneighbors(
         self,
         *,
-        estimator: ImageEstimator[KNeighborsRegressor | KNeighborsClassifier],
+        estimator: ImageEstimator[KNeighborsMixin],
         **kneighbors_kwargs,
     ) -> DaskBackedType | tuple[DaskBackedType, DaskBackedType]:
         """Generic kneighbors wrapper for Dask-backed arrays."""
-        check_is_fitted(estimator)
         return_distance = kneighbors_kwargs.pop("return_distance", True)
 
         k = estimator.n_neighbors

--- a/src/sknnr_spatial/image/dataarray.py
+++ b/src/sknnr_spatial/image/dataarray.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 
     from ..estimator import ImageEstimator
+    from ..types import NoDataType
 
 
 class DataArrayPreprocessor(ImagePreprocessor):
@@ -26,9 +27,7 @@ class DataArrayPreprocessor(ImagePreprocessor):
     _backend = da
     band_dim = 0
 
-    def _validate_nodata_vals(
-        self, nodata_vals: float | tuple[float] | NDArray | None
-    ) -> NDArray | None:
+    def _validate_nodata_vals(self, nodata_vals: NoDataType) -> NDArray | None:
         """
         Get an array of NoData values in the shape (bands,) based on user input and
         DataArray metadata.
@@ -84,7 +83,7 @@ def _predict_from_dataarray(
     *,
     estimator: ImageEstimator[BaseEstimator],
     y=None,
-    nodata_vals=None,
+    nodata_vals: NoDataType = None,
 ) -> xr.DataArray:
     return predict_from_dask_backed_array(
         X_image,
@@ -96,12 +95,12 @@ def _predict_from_dataarray(
 
 @kneighbors.register(xr.DataArray)
 def _kneighbors_from_dataarray(
-    X_image: xr.Dataset,
+    X_image: xr.DataArray,
     *,
     estimator: ImageEstimator[KNeighborsRegressor | KNeighborsClassifier],
-    nodata_vals=None,
+    nodata_vals: NoDataType = None,
     **kneighbors_kwargs,
-) -> xr.Dataset:
+) -> xr.DataArray | tuple[xr.DataArray, xr.DataArray]:
     return kneighbors_from_dask_backed_array(
         X_image,
         estimator=estimator,

--- a/src/sknnr_spatial/image/dataarray.py
+++ b/src/sknnr_spatial/image/dataarray.py
@@ -15,7 +15,9 @@ from ._dask_backed import (
 if TYPE_CHECKING:
     from numpy.typing import NDArray
     from sklearn.base import BaseEstimator
-    from sklearn.neighbors import KNeighborsRegressor
+    from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
+
+    from ..estimator import ImageEstimator
 
 
 class DataArrayPreprocessor(ImagePreprocessor):
@@ -78,7 +80,11 @@ class DataArrayPreprocessor(ImagePreprocessor):
 
 @predict.register(xr.DataArray)
 def _predict_from_dataarray(
-    X_image: xr.DataArray, *, estimator: BaseEstimator, y=None, nodata_vals=None
+    X_image: xr.DataArray,
+    *,
+    estimator: ImageEstimator[BaseEstimator],
+    y=None,
+    nodata_vals=None,
 ) -> xr.DataArray:
     return predict_from_dask_backed_array(
         X_image,
@@ -93,7 +99,7 @@ def _predict_from_dataarray(
 def _kneighbors_from_dataarray(
     X_image: xr.Dataset,
     *,
-    estimator: KNeighborsRegressor,
+    estimator: ImageEstimator[KNeighborsRegressor | KNeighborsClassifier],
     nodata_vals=None,
     **kneighbors_kwargs,
 ) -> xr.Dataset:

--- a/src/sknnr_spatial/image/dataarray.py
+++ b/src/sknnr_spatial/image/dataarray.py
@@ -89,7 +89,6 @@ def _predict_from_dataarray(
     return predict_from_dask_backed_array(
         X_image,
         estimator=estimator,
-        y=y,
         preprocessor_cls=DataArrayPreprocessor,
         nodata_vals=nodata_vals,
     )

--- a/src/sknnr_spatial/image/dataarray.py
+++ b/src/sknnr_spatial/image/dataarray.py
@@ -6,18 +6,12 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
-from ._base import ImagePreprocessor, kneighbors, predict
-from ._dask_backed import (
-    kneighbors_from_dask_backed_array,
-    predict_from_dask_backed_array,
-)
+from ._base import ImagePreprocessor
+from ._dask_backed import DaskBackedWrapper
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
-    from sklearn.base import BaseEstimator
-    from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 
-    from ..estimator import ImageEstimator
     from ..types import NoDataType
 
 
@@ -77,34 +71,7 @@ class DataArrayPreprocessor(ImagePreprocessor):
         )
 
 
-@predict.register(xr.DataArray)
-def _predict_from_dataarray(
-    X_image: xr.DataArray,
-    *,
-    estimator: ImageEstimator[BaseEstimator],
-    y=None,
-    nodata_vals: NoDataType = None,
-) -> xr.DataArray:
-    return predict_from_dask_backed_array(
-        X_image,
-        estimator=estimator,
-        preprocessor_cls=DataArrayPreprocessor,
-        nodata_vals=nodata_vals,
-    )
+class DataArrayWrapper(DaskBackedWrapper[xr.DataArray]):
+    """A wrapper around a DataArray that provides sklearn methods."""
 
-
-@kneighbors.register(xr.DataArray)
-def _kneighbors_from_dataarray(
-    X_image: xr.DataArray,
-    *,
-    estimator: ImageEstimator[KNeighborsRegressor | KNeighborsClassifier],
-    nodata_vals: NoDataType = None,
-    **kneighbors_kwargs,
-) -> xr.DataArray | tuple[xr.DataArray, xr.DataArray]:
-    return kneighbors_from_dask_backed_array(
-        X_image,
-        estimator=estimator,
-        preprocessor_cls=DataArrayPreprocessor,
-        nodata_vals=nodata_vals,
-        **kneighbors_kwargs,
-    )
+    preprocessor_cls = DataArrayPreprocessor

--- a/src/sknnr_spatial/image/dataset.py
+++ b/src/sknnr_spatial/image/dataset.py
@@ -15,7 +15,9 @@ from .dataarray import DataArrayPreprocessor
 if TYPE_CHECKING:
     from numpy.typing import NDArray
     from sklearn.base import BaseEstimator
-    from sklearn.neighbors import KNeighborsRegressor
+    from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
+
+    from ..estimator import ImageEstimator
 
 
 class DatasetPreprocessor(DataArrayPreprocessor):
@@ -77,7 +79,11 @@ class DatasetPreprocessor(DataArrayPreprocessor):
 
 @predict.register(xr.Dataset)
 def _predict_from_dataset(
-    X_image: xr.Dataset, *, estimator: BaseEstimator, y=None, nodata_vals=None
+    X_image: xr.Dataset,
+    *,
+    estimator: ImageEstimator[BaseEstimator],
+    y=None,
+    nodata_vals=None,
 ) -> xr.Dataset:
     return predict_from_dask_backed_array(
         X_image,
@@ -92,7 +98,7 @@ def _predict_from_dataset(
 def _kneighbors_from_dataset(
     X_image: xr.Dataset,
     *,
-    estimator: KNeighborsRegressor,
+    estimator: ImageEstimator[KNeighborsRegressor | KNeighborsClassifier],
     nodata_vals=None,
     **kneighbors_kwargs,
 ) -> xr.Dataset:

--- a/src/sknnr_spatial/image/dataset.py
+++ b/src/sknnr_spatial/image/dataset.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 
     from ..estimator import ImageEstimator
+    from ..types import NoDataType
 
 
 class DatasetPreprocessor(DataArrayPreprocessor):
@@ -31,7 +32,7 @@ class DatasetPreprocessor(DataArrayPreprocessor):
     def __init__(
         self,
         image: xr.Dataset,
-        nodata_vals: float | tuple[float] | NDArray | None = None,
+        nodata_vals: NoDataType = None,
         nan_fill: float | None = 0.0,
     ):
         # The image itself will be stored as a DataArray, but keep the Dataset for
@@ -39,9 +40,7 @@ class DatasetPreprocessor(DataArrayPreprocessor):
         self.dataset = image
         super().__init__(image.to_dataarray(), nodata_vals, nan_fill)
 
-    def _validate_nodata_vals(
-        self, nodata_vals: float | tuple[float] | NDArray | None
-    ) -> NDArray | None:
+    def _validate_nodata_vals(self, nodata_vals: NoDataType) -> NDArray | None:
         """
         Get an array of NoData values in the shape (bands,) based on user input and
         Dataset metadata.
@@ -82,7 +81,7 @@ def _predict_from_dataset(
     X_image: xr.Dataset,
     *,
     estimator: ImageEstimator[BaseEstimator],
-    nodata_vals=None,
+    nodata_vals: NoDataType = None,
 ) -> xr.Dataset:
     return predict_from_dask_backed_array(
         X_image,
@@ -97,9 +96,9 @@ def _kneighbors_from_dataset(
     X_image: xr.Dataset,
     *,
     estimator: ImageEstimator[KNeighborsRegressor | KNeighborsClassifier],
-    nodata_vals=None,
+    nodata_vals: NoDataType = None,
     **kneighbors_kwargs,
-) -> xr.Dataset:
+) -> xr.Dataset | tuple[xr.Dataset, xr.Dataset]:
     return kneighbors_from_dask_backed_array(
         X_image,
         estimator=estimator,

--- a/src/sknnr_spatial/image/dataset.py
+++ b/src/sknnr_spatial/image/dataset.py
@@ -82,13 +82,11 @@ def _predict_from_dataset(
     X_image: xr.Dataset,
     *,
     estimator: ImageEstimator[BaseEstimator],
-    y=None,
     nodata_vals=None,
 ) -> xr.Dataset:
     return predict_from_dask_backed_array(
         X_image,
         estimator=estimator,
-        y=y,
         preprocessor_cls=DatasetPreprocessor,
         nodata_vals=nodata_vals,
     )

--- a/src/sknnr_spatial/image/dataset.py
+++ b/src/sknnr_spatial/image/dataset.py
@@ -5,19 +5,12 @@ from typing import TYPE_CHECKING
 import numpy as np
 import xarray as xr
 
-from ._base import kneighbors, predict
-from ._dask_backed import (
-    kneighbors_from_dask_backed_array,
-    predict_from_dask_backed_array,
-)
+from ._dask_backed import DaskBackedWrapper
 from .dataarray import DataArrayPreprocessor
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
-    from sklearn.base import BaseEstimator
-    from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 
-    from ..estimator import ImageEstimator
     from ..types import NoDataType
 
 
@@ -76,33 +69,7 @@ class DatasetPreprocessor(DataArrayPreprocessor):
         )
 
 
-@predict.register(xr.Dataset)
-def _predict_from_dataset(
-    X_image: xr.Dataset,
-    *,
-    estimator: ImageEstimator[BaseEstimator],
-    nodata_vals: NoDataType = None,
-) -> xr.Dataset:
-    return predict_from_dask_backed_array(
-        X_image,
-        estimator=estimator,
-        preprocessor_cls=DatasetPreprocessor,
-        nodata_vals=nodata_vals,
-    )
+class DatasetWrapper(DaskBackedWrapper[xr.Dataset]):
+    """A wrapper around a Dataset that provides sklearn methods."""
 
-
-@kneighbors.register(xr.Dataset)
-def _kneighbors_from_dataset(
-    X_image: xr.Dataset,
-    *,
-    estimator: ImageEstimator[KNeighborsRegressor | KNeighborsClassifier],
-    nodata_vals: NoDataType = None,
-    **kneighbors_kwargs,
-) -> xr.Dataset | tuple[xr.Dataset, xr.Dataset]:
-    return kneighbors_from_dask_backed_array(
-        X_image,
-        estimator=estimator,
-        preprocessor_cls=DatasetPreprocessor,
-        nodata_vals=nodata_vals,
-        **kneighbors_kwargs,
-    )
+    preprocessor_cls = DatasetPreprocessor

--- a/src/sknnr_spatial/image/ndarray.py
+++ b/src/sknnr_spatial/image/ndarray.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 
     from ..estimator import ImageEstimator
+    from ..types import NoDataType
 
 
 class NDArrayPreprocessor(ImagePreprocessor):
@@ -36,7 +37,10 @@ class NDArrayPreprocessor(ImagePreprocessor):
 
 @predict.register(np.ndarray)
 def _predict_from_ndarray(
-    X_image: NDArray, *, estimator: ImageEstimator[BaseEstimator], nodata_vals=None
+    X_image: NDArray,
+    *,
+    estimator: ImageEstimator[BaseEstimator],
+    nodata_vals: NoDataType = None,
 ) -> NDArray:
     """Predict attributes from an array of X_image."""
     check_is_fitted(estimator)
@@ -57,9 +61,9 @@ def _kneighbors_from_ndarray(
     X_image: NDArray,
     *,
     estimator: ImageEstimator[KNeighborsRegressor | KNeighborsClassifier],
-    nodata_vals=None,
+    nodata_vals: NoDataType = None,
     **kneighbors_kwargs,
-) -> NDArray:
+) -> NDArray | tuple[NDArray, NDArray]:
     check_is_fitted(estimator)
     preprocessor = NDArrayPreprocessor(X_image, nodata_vals=nodata_vals)
     return_distance = kneighbors_kwargs.pop("return_distance", True)

--- a/src/sknnr_spatial/image/ndarray.py
+++ b/src/sknnr_spatial/image/ndarray.py
@@ -45,6 +45,10 @@ def _predict_from_ndarray(
     # TODO: Deal with sklearn warning about missing feature names
     y_pred_flat = estimator._wrapped.predict(preprocessor.flat)
 
+    # Reshape from (n_samples,) to (n_samples, 1)
+    if estimator._wrapped_meta.n_targets == 1:
+        y_pred_flat = y_pred_flat.reshape(-1, 1)
+
     return preprocessor.unflatten(y_pred_flat, apply_mask=True)
 
 

--- a/src/sknnr_spatial/image/ndarray.py
+++ b/src/sknnr_spatial/image/ndarray.py
@@ -3,17 +3,16 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
+from numpy.typing import NDArray
 from sklearn.utils.validation import check_is_fitted
 
-from ._base import ImagePreprocessor, kneighbors, predict
+from ._base import ImagePreprocessor, ImageWrapper
 
 if TYPE_CHECKING:
-    from numpy.typing import NDArray
     from sklearn.base import BaseEstimator
     from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 
     from ..estimator import ImageEstimator
-    from ..types import NoDataType
 
 
 class NDArrayPreprocessor(ImagePreprocessor):
@@ -35,50 +34,46 @@ class NDArrayPreprocessor(ImagePreprocessor):
         return flat_image.reshape(*self.image.shape[:2], -1)
 
 
-@predict.register(np.ndarray)
-def _predict_from_ndarray(
-    X_image: NDArray,
-    *,
-    estimator: ImageEstimator[BaseEstimator],
-    nodata_vals: NoDataType = None,
-) -> NDArray:
-    """Predict attributes from an array of X_image."""
-    check_is_fitted(estimator)
-    preprocessor = NDArrayPreprocessor(X_image, nodata_vals=nodata_vals)
+class NDArrayWrapper(ImageWrapper[NDArray]):
+    preprocessor_cls = NDArrayPreprocessor
 
-    # TODO: Deal with sklearn warning about missing feature names
-    y_pred_flat = estimator._wrapped.predict(preprocessor.flat)
+    def predict(
+        self,
+        *,
+        estimator: ImageEstimator[BaseEstimator],
+    ) -> NDArray:
+        """Predict attributes from an array of X_image."""
+        check_is_fitted(estimator)
 
-    # Reshape from (n_samples,) to (n_samples, 1)
-    if estimator._wrapped_meta.n_targets == 1:
-        y_pred_flat = y_pred_flat.reshape(-1, 1)
+        # TODO: Deal with sklearn warning about missing feature names
+        y_pred_flat = estimator._wrapped.predict(self.preprocessor.flat)
 
-    return preprocessor.unflatten(y_pred_flat, apply_mask=True)
+        # Reshape from (n_samples,) to (n_samples, 1)
+        if estimator._wrapped_meta.n_targets == 1:
+            y_pred_flat = y_pred_flat.reshape(-1, 1)
 
+        return self.preprocessor.unflatten(y_pred_flat, apply_mask=True)
 
-@kneighbors.register(np.ndarray)
-def _kneighbors_from_ndarray(
-    X_image: NDArray,
-    *,
-    estimator: ImageEstimator[KNeighborsRegressor | KNeighborsClassifier],
-    nodata_vals: NoDataType = None,
-    **kneighbors_kwargs,
-) -> NDArray | tuple[NDArray, NDArray]:
-    check_is_fitted(estimator)
-    preprocessor = NDArrayPreprocessor(X_image, nodata_vals=nodata_vals)
-    return_distance = kneighbors_kwargs.pop("return_distance", True)
-
-    result = estimator._wrapped.kneighbors(
-        preprocessor.flat,
-        return_distance=return_distance,
+    def kneighbors(
+        self,
+        *,
+        estimator: ImageEstimator[KNeighborsRegressor | KNeighborsClassifier],
         **kneighbors_kwargs,
-    )
-    if return_distance:
-        dist, nn = result
+    ) -> NDArray | tuple[NDArray, NDArray]:
+        check_is_fitted(estimator)
+        return_distance = kneighbors_kwargs.pop("return_distance", True)
 
-        dist = preprocessor.unflatten(dist)
-        nn = preprocessor.unflatten(nn)
+        result = estimator._wrapped.kneighbors(
+            self.preprocessor.flat,
+            return_distance=return_distance,
+            **kneighbors_kwargs,
+        )
+        if return_distance:
+            dist, nn = result
 
-        return dist, nn
+            dist = self.preprocessor.unflatten(dist)
+            nn = self.preprocessor.unflatten(nn)
 
-    return preprocessor.unflatten(result)
+            return dist, nn
+
+        return self.preprocessor.unflatten(result)

--- a/src/sknnr_spatial/image/ndarray.py
+++ b/src/sknnr_spatial/image/ndarray.py
@@ -4,13 +4,12 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy.typing import NDArray
-from sklearn.utils.validation import check_is_fitted
 
 from ._base import ImagePreprocessor, ImageWrapper
 
 if TYPE_CHECKING:
     from sklearn.base import BaseEstimator
-    from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
+    from sklearn.neighbors._base import KNeighborsMixin
 
     from ..estimator import ImageEstimator
 
@@ -43,8 +42,6 @@ class NDArrayWrapper(ImageWrapper[NDArray]):
         estimator: ImageEstimator[BaseEstimator],
     ) -> NDArray:
         """Predict attributes from an array of X_image."""
-        check_is_fitted(estimator)
-
         # TODO: Deal with sklearn warning about missing feature names
         y_pred_flat = estimator._wrapped.predict(self.preprocessor.flat)
 
@@ -57,10 +54,9 @@ class NDArrayWrapper(ImageWrapper[NDArray]):
     def kneighbors(
         self,
         *,
-        estimator: ImageEstimator[KNeighborsRegressor | KNeighborsClassifier],
+        estimator: ImageEstimator[KNeighborsMixin],
         **kneighbors_kwargs,
     ) -> NDArray | tuple[NDArray, NDArray]:
-        check_is_fitted(estimator)
         return_distance = kneighbors_kwargs.pop("return_distance", True)
 
         result = estimator._wrapped.kneighbors(

--- a/src/sknnr_spatial/types.py
+++ b/src/sknnr_spatial/types.py
@@ -1,7 +1,10 @@
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import xarray as xr
 from numpy.typing import NDArray
+from sklearn.base import BaseEstimator
 
 DaskBackedType = TypeVar("DaskBackedType", xr.DataArray, xr.Dataset)
 ImageType = TypeVar("ImageType", NDArray, xr.DataArray, xr.Dataset)
+EstimatorType = TypeVar("EstimatorType", bound=BaseEstimator)
+AnyType = TypeVar("AnyType", bound=Any)

--- a/src/sknnr_spatial/types.py
+++ b/src/sknnr_spatial/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any, TypeVar
+from typing import Any, TypeVar, Union
 
 import xarray as xr
 from numpy.typing import NDArray
@@ -11,4 +11,4 @@ DaskBackedType = TypeVar("DaskBackedType", xr.DataArray, xr.Dataset)
 ImageType = TypeVar("ImageType", NDArray, xr.DataArray, xr.Dataset)
 EstimatorType = TypeVar("EstimatorType", bound=BaseEstimator)
 AnyType = TypeVar("AnyType", bound=Any)
-NoDataType = float | Sequence[float] | None
+NoDataType = Union[float, Sequence[float], None]

--- a/src/sknnr_spatial/types.py
+++ b/src/sknnr_spatial/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
 from typing import Any, TypeVar
 

--- a/src/sknnr_spatial/types.py
+++ b/src/sknnr_spatial/types.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import Any, TypeVar
 
 import xarray as xr
@@ -8,3 +9,4 @@ DaskBackedType = TypeVar("DaskBackedType", xr.DataArray, xr.Dataset)
 ImageType = TypeVar("ImageType", NDArray, xr.DataArray, xr.Dataset)
 EstimatorType = TypeVar("EstimatorType", bound=BaseEstimator)
 AnyType = TypeVar("AnyType", bound=Any)
+NoDataType = float | Sequence[float] | None

--- a/src/sknnr_spatial/utils/estimator.py
+++ b/src/sknnr_spatial/utils/estimator.py
@@ -40,7 +40,7 @@ def check_wrapper_implements(func: Callable) -> Callable:
     return wrapper
 
 
-def check_is_x_image(func: Callable) -> Callable:
+def image_or_fallback(func: Callable) -> Callable:
     """Decorator that calls the wrapped method for non-image X arrays."""
 
     @wraps(func)

--- a/src/sknnr_spatial/utils/estimator.py
+++ b/src/sknnr_spatial/utils/estimator.py
@@ -1,0 +1,61 @@
+from functools import wraps
+from typing import Callable, Generic
+
+from sklearn.base import BaseEstimator
+from sklearn.utils.validation import NotFittedError, check_is_fitted
+
+from ..types import AnyType
+from .image import is_image_type
+
+
+class AttrWrapper(Generic[AnyType]):
+    """A transparent object wrapper that accesses a wrapped object's attributes."""
+
+    _wrapped: AnyType
+
+    def __init__(self, wrapped: AnyType):
+        self._wrapped = wrapped
+
+    def __getattr__(self, name: str):
+        return getattr(self._wrapped, name)
+
+    @property
+    def __dict__(self):
+        return self._wrapped.__dict__
+
+
+def check_wrapper_implements(func: Callable) -> Callable:
+    """Decorator that raises if the wrapped instance doesn't implement the method."""
+
+    @wraps(func)
+    def wrapper(self: AttrWrapper, *args, **kwargs):
+        if not hasattr(self._wrapped, func.__name__):
+            wrapped_class = self._wrapped.__class__.__name__
+            msg = f"{wrapped_class} does not implement {func.__name__}."
+            raise NotImplementedError(msg)
+
+        return func(self, *args, **kwargs)
+
+    return wrapper
+
+
+def check_is_x_image(func: Callable) -> Callable:
+    """Decorator that calls the wrapped method for non-image X arrays."""
+
+    @wraps(func)
+    def wrapper(self: AttrWrapper, X, *args, **kwargs):
+        if not is_image_type(X):
+            return getattr(self._wrapped, func.__name__)(X, *args, **kwargs)
+
+        return func(self, X, *args, **kwargs)
+
+    return wrapper
+
+
+def is_fitted(estimator: BaseEstimator) -> bool:
+    """Return whether an estimator is fitted or not."""
+    try:
+        check_is_fitted(estimator)
+        return True
+    except NotFittedError:
+        return False

--- a/src/sknnr_spatial/utils/estimator.py
+++ b/src/sknnr_spatial/utils/estimator.py
@@ -4,7 +4,8 @@ from typing import Callable, Generic
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import NotFittedError, check_is_fitted
 
-from ..types import AnyType, ImageType
+from ..image._base import ImageType
+from ..types import AnyType
 from .image import is_image_type
 
 

--- a/src/sknnr_spatial/utils/estimator.py
+++ b/src/sknnr_spatial/utils/estimator.py
@@ -4,7 +4,7 @@ from typing import Callable, Generic
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import NotFittedError, check_is_fitted
 
-from ..types import AnyType
+from ..types import AnyType, ImageType
 from .image import is_image_type
 
 
@@ -43,11 +43,11 @@ def check_is_x_image(func: Callable) -> Callable:
     """Decorator that calls the wrapped method for non-image X arrays."""
 
     @wraps(func)
-    def wrapper(self: AttrWrapper, X, *args, **kwargs):
-        if not is_image_type(X):
-            return getattr(self._wrapped, func.__name__)(X, *args, **kwargs)
+    def wrapper(self: AttrWrapper, X_image: ImageType, *args, **kwargs):
+        if not is_image_type(X_image):
+            return getattr(self._wrapped, func.__name__)(X_image, *args, **kwargs)
 
-        return func(self, X, *args, **kwargs)
+        return func(self, X_image, *args, **kwargs)
 
     return wrapper
 

--- a/src/sknnr_spatial/utils/image.py
+++ b/src/sknnr_spatial/utils/image.py
@@ -1,7 +1,10 @@
 import numpy as np
 import xarray as xr
 
-from ..types import ImageType
+from ..image._base import ImageType, ImageWrapper
+from ..image.dataarray import DataArrayWrapper
+from ..image.dataset import DatasetWrapper
+from ..image.ndarray import NDArrayWrapper
 
 
 def is_image_type(X: ImageType) -> bool:
@@ -14,3 +17,15 @@ def is_image_type(X: ImageType) -> bool:
         return len(X.dims) == 2
 
     return False
+
+
+def get_image_wrapper(x_image: ImageType) -> type[ImageWrapper]:
+    """Get an ImageWrapper subclass for a given image."""
+    if isinstance(x_image, np.ndarray):
+        return NDArrayWrapper
+    if isinstance(x_image, xr.DataArray):
+        return DataArrayWrapper
+    if isinstance(x_image, xr.Dataset):
+        return DatasetWrapper
+
+    raise TypeError(f"Unsupported image type: {type(x_image).__name__}")

--- a/src/sknnr_spatial/utils/image.py
+++ b/src/sknnr_spatial/utils/image.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import numpy as np
 import xarray as xr
 
@@ -7,7 +9,7 @@ from ..image.dataset import DatasetWrapper
 from ..image.ndarray import NDArrayWrapper
 
 
-def is_image_type(X: ImageType) -> bool:
+def is_image_type(X: Any) -> bool:
     # Feature array images must have exactly 3 dimensions: (y, x, band) or (band, y, x)
     if isinstance(X, (np.ndarray, xr.DataArray)):
         return X.ndim == 3
@@ -19,13 +21,13 @@ def is_image_type(X: ImageType) -> bool:
     return False
 
 
-def get_image_wrapper(x_image: ImageType) -> type[ImageWrapper]:
+def get_image_wrapper(X_image: ImageType) -> type[ImageWrapper]:
     """Get an ImageWrapper subclass for a given image."""
-    if isinstance(x_image, np.ndarray):
+    if isinstance(X_image, np.ndarray):
         return NDArrayWrapper
-    if isinstance(x_image, xr.DataArray):
+    if isinstance(X_image, xr.DataArray):
         return DataArrayWrapper
-    if isinstance(x_image, xr.Dataset):
+    if isinstance(X_image, xr.Dataset):
         return DatasetWrapper
 
-    raise TypeError(f"Unsupported image type: {type(x_image).__name__}")
+    raise TypeError(f"Unsupported image type: {type(X_image).__name__}")

--- a/src/sknnr_spatial/utils/image.py
+++ b/src/sknnr_spatial/utils/image.py
@@ -1,0 +1,16 @@
+import numpy as np
+import xarray as xr
+
+from ..types import ImageType
+
+
+def is_image_type(X: ImageType) -> bool:
+    # Feature array images must have exactly 3 dimensions: (y, x, band) or (band, y, x)
+    if isinstance(X, (np.ndarray, xr.DataArray)):
+        return X.ndim == 3
+
+    # Feature Dataset images must have exactly 2 dimensions: (x, y)
+    if isinstance(X, xr.Dataset):
+        return len(X.dims) == 2
+
+    return False

--- a/src/sknnr_spatial/wrapper.py
+++ b/src/sknnr_spatial/wrapper.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from functools import wraps
+from typing import Callable
+from warnings import warn
+
+from sklearn.base import BaseEstimator, clone
+from sklearn.utils.validation import NotFittedError, check_is_fitted
+
+from .image._base import is_image_type, kneighbors, predict
+
+
+class _AttrWrapper:
+    """A transparent object wrapper that accesses a wrapped object's attributes."""
+
+    def __init__(self, wrapped):
+        self._wrapped = wrapped
+
+    def __getattr__(self, name: str):
+        return getattr(self._wrapped, name)
+
+    @property
+    def __dict__(self):
+        return self._wrapped.__dict__
+
+    @staticmethod
+    def check_for_wrapped_method(func: Callable) -> Callable:
+        """Check that the method is implemented by the caller's wrapped instance."""
+
+        @wraps(func)
+        def wrapper(self: _AttrWrapper, *args, **kwargs):
+            if not hasattr(self._wrapped, func.__name__):
+                wrapped_class = self._wrapped.__class__.__name__
+                msg = f"{wrapped_class} does not implement {func.__name__}."
+                raise NotImplementedError(msg)
+
+            return func(self, *args, **kwargs)
+
+        return wrapper
+
+
+class SpatialEstimator(_AttrWrapper):
+    def __init__(self, wrapped: BaseEstimator):
+        self._wrapped = self._reset_estimator(wrapped)
+
+    @staticmethod
+    def _reset_estimator(estimator: BaseEstimator) -> BaseEstimator:
+        """Take an estimator and reset and warn if it was previously fitted."""
+        try:
+            check_is_fitted(estimator)
+            warn(
+                "Wrapping estimator that has already been fit. The estimator must be "
+                "fit again after wrapping.",
+                stacklevel=2,
+            )
+
+            return clone(estimator)
+        except NotFittedError:
+            return estimator
+
+    @_AttrWrapper.check_for_wrapped_method
+    def fit(self, X, y=None, **kwargs) -> SpatialEstimator:
+        """Fit the wrapped estimator and return the wrapper."""
+        self._wrapped = self._wrapped.fit(X, y, **kwargs)
+        # TODO: Store all needed metadata, e.g. n targets, target names, etc.
+        # TODO: Override the builtin feature name warning somehow
+        return self
+
+    @_AttrWrapper.check_for_wrapped_method
+    def predict(self, X):
+        # Allow predicting with non-image data using the wrapped estimator
+        if not is_image_type(X):
+            return self._wrapped.predict(X)
+
+        return predict(X, estimator=self._wrapped)
+
+    @_AttrWrapper.check_for_wrapped_method
+    def kneighbors(self, X, return_distance=True, **kwargs):
+        # Allow kneighbors with non-image data using the wrapped estimator
+        if not is_image_type(X):
+            return self._wrapped.kneighbors(
+                X, return_distance=return_distance, **kwargs
+            )
+
+        return kneighbors(
+            X, return_distance=return_distance, estimator=self._wrapped, **kwargs
+        )
+
+
+def wrap(estimator: BaseEstimator) -> SpatialEstimator:
+    return SpatialEstimator(estimator)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import numpy as np
+import pytest
+
+
+@pytest.fixture()
+def dummy_model_data():
+    n_features = 5
+    n_rows = 10
+
+    X_image = np.random.rand(8, 16, n_features)
+    X = np.random.rand(n_rows, n_features)
+    y = np.random.rand(n_rows, 3)
+
+    return X_image, X, y

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -7,7 +7,12 @@ from sknnr_spatial.image.dataarray import DataArrayPreprocessor
 from sknnr_spatial.image.dataset import DatasetPreprocessor
 from sknnr_spatial.image.ndarray import NDArrayPreprocessor
 
-from .image_utils import TestImageType, parametrize_image_types, unwrap, wrap
+from .image_utils import (
+    TestImageType,
+    parametrize_image_types,
+    unwrap_image,
+    wrap_image,
+)
 
 
 @parametrize_image_types
@@ -16,7 +21,7 @@ def test_input_array_not_mutated(image_type):
     array = np.array([[[0, 1]], [[1, np.nan]]])
     original_array = array.copy()
 
-    img = wrap(array, type=image_type.cls)
+    img = wrap_image(array, type=image_type.cls)
 
     preprocessor = image_type.preprocessor(img, nodata_vals=0)
     preprocessor.unflatten(preprocessor.flat)
@@ -29,19 +34,19 @@ def test_flat_nans_filled(image_type: TestImageType):
     """NaNs in the flat image should always be filled."""
     fill_value = 42.0
 
-    with_nans = wrap(
+    with_nans = wrap_image(
         np.array([[[1, np.nan, 1], [1, 1, 1]], [[1, 1, 1], [1, 1, np.nan]]]),
         type=image_type.cls,
     )
 
-    filled = wrap(
+    filled = wrap_image(
         np.array([[[1, fill_value, 1], [1, 1, 1]], [[1, 1, 1], [1, 1, fill_value]]]),
         type=image_type.cls,
     )
 
     preprocessor = image_type.preprocessor
-    flat_with_nans = unwrap(preprocessor(with_nans, nan_fill=fill_value).flat)
-    flat_filled = unwrap(preprocessor(filled, nan_fill=fill_value).flat)
+    flat_with_nans = unwrap_image(preprocessor(with_nans, nan_fill=fill_value).flat)
+    flat_filled = unwrap_image(preprocessor(filled, nan_fill=fill_value).flat)
 
     assert_array_equal(flat_with_nans, flat_filled)
 
@@ -52,10 +57,10 @@ def test_flatten(image_type: TestImageType):
     n_bands = 3
     array = np.ones((2, 2, n_bands))
 
-    img = wrap(array, type=image_type.cls)
+    img = wrap_image(array, type=image_type.cls)
 
     preprocessor = image_type.preprocessor(img)
-    flat = unwrap(preprocessor.flat)
+    flat = unwrap_image(preprocessor.flat)
 
     assert flat.shape == (4, n_bands)
     assert_array_equal(flat, np.ones((4, n_bands)))
@@ -68,10 +73,10 @@ def test_flatten_is_reversible(image_type: TestImageType, dtype, nodata_vals):
     """Unflattening a flattened image should return the original image."""
     array = np.random.randint(0, 1e4, (2, 2, 3)).astype(dtype)
 
-    img = wrap(array, type=image_type.cls)
+    img = wrap_image(array, type=image_type.cls)
     preprocessor = image_type.preprocessor(img, nodata_vals=nodata_vals)
 
-    unflattened = unwrap(preprocessor.unflatten(preprocessor.flat))
+    unflattened = unwrap_image(preprocessor.unflatten(preprocessor.flat))
 
     assert_array_equal(unflattened, array)
 
@@ -83,10 +88,10 @@ def test_unflatten_masks_nans(image_type):
     array = np.random.rand(2, 2, 1)
     array[0, 0, 0] = np.nan
 
-    img = wrap(array, type=image_type.cls)
+    img = wrap_image(array, type=image_type.cls)
     preprocessor = image_type.preprocessor(img)
 
-    unflattened = unwrap(preprocessor.unflatten(preprocessor.flat))
+    unflattened = unwrap_image(preprocessor.unflatten(preprocessor.flat))
 
     assert_array_equal(unflattened, array)
 
@@ -220,6 +225,6 @@ def test_wrappers(image_type):
     """Confirm that the test wrappers function as expected."""
     array = np.random.rand(32, 16, 3)
 
-    wrapped = wrap(array, type=image_type.cls)
+    wrapped = wrap_image(array, type=image_type.cls)
     assert isinstance(wrapped, image_type.cls)
-    assert_array_equal(unwrap(wrapped), array)
+    assert_array_equal(unwrap_image(wrapped), array)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -5,13 +5,13 @@ from numpy.testing import assert_array_equal
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.neighbors import KNeighborsRegressor
 
-from sknnr_spatial import kneighbors, predict
+from sknnr_spatial import wrap
 
 from .image_utils import (
     parametrize_image_types,
     parametrize_xarray_image_types,
-    unwrap,
-    wrap,
+    unwrap_image,
+    wrap_image,
 )
 
 
@@ -28,14 +28,14 @@ def dummy_model_data():
 
 
 @parametrize_image_types
-@pytest.mark.parametrize("estimator", [KNeighborsRegressor(), RandomForestRegressor()])
+@pytest.mark.parametrize("estimator", [KNeighborsRegressor, RandomForestRegressor])
 def test_predict(dummy_model_data, image_type, estimator):
     """Test that predict works with all image types and a few estimators."""
     X_image, X, y = dummy_model_data
-    estimator = estimator.fit(X, y)
+    estimator = wrap(estimator()).fit(X, y)
 
-    X_wrapped = wrap(X_image, type=image_type.cls)
-    y_pred = unwrap(predict(X_wrapped, estimator=estimator))
+    X_wrapped = wrap_image(X_image, type=image_type.cls)
+    y_pred = unwrap_image(estimator.predict(X_wrapped))
 
     assert y_pred.ndim == 3
     assert_array_equal(y_pred.shape, (X_image.shape[0], X_image.shape[1], y.shape[-1]))
@@ -46,12 +46,12 @@ def test_kneighbors_with_distance(dummy_model_data, image_type):
     """Test kneighbors works with all image types when returning distance."""
     k = 3
     X_image, X, y = dummy_model_data
-    estimator = KNeighborsRegressor(n_neighbors=k).fit(X, y)
+    estimator = wrap(KNeighborsRegressor(n_neighbors=k)).fit(X, y)
 
-    X_wrapped = wrap(X_image, type=image_type.cls)
-    dist, nn = kneighbors(X_wrapped, estimator=estimator, return_distance=True)
-    dist = unwrap(dist)
-    nn = unwrap(nn)
+    X_wrapped = wrap_image(X_image, type=image_type.cls)
+    dist, nn = estimator.kneighbors(X_wrapped, return_distance=True)
+    dist = unwrap_image(dist)
+    nn = unwrap_image(nn)
 
     assert dist.ndim == 3
     assert nn.ndim == 3
@@ -65,11 +65,11 @@ def test_kneighbors_without_distance(dummy_model_data, image_type):
     """Test kneighbors works with all image types when NOT returning distance."""
     k = 3
     X_image, X, y = dummy_model_data
-    estimator = KNeighborsRegressor(n_neighbors=k).fit(X, y)
+    estimator = wrap(KNeighborsRegressor(n_neighbors=k)).fit(X, y)
 
-    X_wrapped = wrap(X_image, type=image_type.cls)
-    nn = kneighbors(X_wrapped, estimator=estimator, return_distance=False)
-    nn = unwrap(nn)
+    X_wrapped = wrap_image(X_image, type=image_type.cls)
+    nn = estimator.kneighbors(X_wrapped, return_distance=False)
+    nn = unwrap_image(nn)
 
     assert nn.ndim == 3
 
@@ -79,10 +79,10 @@ def test_kneighbors_without_distance(dummy_model_data, image_type):
 def test_predict_dataarray_with_custom_dim_name(dummy_model_data):
     """Test that predict works if the band dimension is not named "variable"."""
     X_image, X, y = dummy_model_data
-    estimator = KNeighborsRegressor().fit(X, y)
-    X_wrapped = wrap(X_image, type=xr.DataArray).rename({"variable": "band"})
+    estimator = wrap(KNeighborsRegressor()).fit(X, y)
+    X_wrapped = wrap_image(X_image, type=xr.DataArray).rename({"variable": "band"})
 
-    y_pred = unwrap(predict(X_wrapped, estimator=estimator))
+    y_pred = unwrap_image(estimator.predict(X_wrapped))
     assert y_pred.ndim == 3
     assert_array_equal(y_pred.shape, (X_image.shape[0], X_image.shape[1], y.shape[-1]))
 
@@ -92,14 +92,14 @@ def test_predict_dataarray_with_custom_dim_name(dummy_model_data):
 def test_crs_preserved(dummy_model_data, image_type, crs):
     """Test that the original image CRS is preserved."""
     X_image, X, y = dummy_model_data
-    estimator = KNeighborsRegressor().fit(X, y)
-    X_wrapped = wrap(X_image, type=image_type.cls)
+    estimator = wrap(KNeighborsRegressor()).fit(X, y)
+    X_wrapped = wrap_image(X_image, type=image_type.cls)
 
     if crs:
         X_wrapped = X_wrapped.rio.write_crs(crs)
 
-    y_pred = predict(X_wrapped, estimator=estimator)
-    dist, nn = kneighbors(X_wrapped, estimator=estimator, return_distance=True)
+    y_pred = estimator.predict(X_wrapped)
+    dist, nn = estimator.kneighbors(X_wrapped, return_distance=True)
 
     assert y_pred.rio.crs == crs
     assert dist.rio.crs == crs

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -94,22 +94,17 @@ def test_crs_preserved(dummy_model_data, image_type, crs):
     assert nn.rio.crs == crs
 
 
-def test_predict_non_image_data(dummy_model_data):
-    """Test that predicting with non-image data falls back to the wrapped estimator."""
+def test_with_non_image_data(dummy_model_data):
+    """Test that non-image data falls back to the wrapped estimator behavior."""
     _, X, y = dummy_model_data
     estimator = KNeighborsRegressor().fit(X, y)
     reference_pred = estimator.predict(X)
-
-    check_pred = wrap(clone(estimator)).fit(X, y).predict(X)
-    assert_array_equal(reference_pred, check_pred)
-
-
-def test_kneighbors_non_image_data(dummy_model_data):
-    """Test that kneighbors with non-image data falls back to the wrapped estimator."""
-    _, X, y = dummy_model_data
-    estimator = KNeighborsRegressor().fit(X, y)
     ref_dist, ref_nn = estimator.kneighbors(X)
 
-    check_dist, check_nn = wrap(clone(estimator)).fit(X, y).kneighbors(X)
+    wrapped = wrap(clone(estimator)).fit(X, y)
+    check_pred = wrapped.predict(X)
+    check_dist, check_nn = wrapped.kneighbors(X)
+
+    assert_array_equal(reference_pred, check_pred)
     assert_array_equal(ref_dist, check_dist)
     assert_array_equal(ref_nn, check_nn)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -94,6 +94,8 @@ def test_predict_dataarray_with_custom_dim_name(dummy_model_data):
 @pytest.mark.parametrize("crs", ["EPSG:5070", None])
 def test_crs_preserved(dummy_model_data, image_type, crs):
     """Test that the original image CRS is preserved."""
+    import rioxarray  # noqa: F401
+
     X_image, X, y = dummy_model_data
     estimator = wrap(KNeighborsRegressor()).fit(X, y)
     X_wrapped = wrap_image(X_image, type=image_type.cls)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_array_equal
 from sklearn.base import clone
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.neighbors import KNeighborsRegressor
+from sklearn.utils.validation import NotFittedError
 
 from sknnr_spatial import wrap
 
@@ -155,3 +156,16 @@ def test_predicted_var_names(dummy_model_data, image_type, fit_with):
         var_names = y_pred.data_vars
 
     assert list(var_names) == expected_var_names
+
+
+def test_raises_if_not_fitted(dummy_model_data):
+    """Test that wrapped methods raise correctly if the estimator is not fitted."""
+    X_image, _, _ = dummy_model_data
+    estimator = KNeighborsRegressor()
+    wrapped = wrap(estimator)
+
+    with pytest.raises(NotFittedError):
+        wrapped.predict(X_image)
+
+    with pytest.raises(NotFittedError):
+        wrapped.kneighbors(X_image)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,0 +1,35 @@
+import pytest
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.neighbors import KNeighborsRegressor
+
+from sknnr_spatial import wrap
+from sknnr_spatial.estimator import is_fitted
+
+
+def test_unimplemented_methods_raise():
+    """Wrapped estimators should raise NotImplementedError for unimplemented methods."""
+    estimator = wrap(RandomForestRegressor())
+    with pytest.raises(NotImplementedError):
+        estimator.kneighbors()
+
+
+def test_wrapping_fitted_estimators_warns(dummy_model_data):
+    """Wrapping fitted estimators should raise a warning and reset the estimator."""
+    _, X, y = dummy_model_data
+
+    with pytest.warns(match="has already been fit"):
+        estimator = wrap(KNeighborsRegressor().fit(X, y))
+
+    assert not is_fitted(estimator._wrapped)
+
+
+def test_wrapper_is_fitted(dummy_model_data):
+    """A wrapper should appear fitted after fitting the wrapped estimator."""
+    _, X, y = dummy_model_data
+
+    estimator = wrap(KNeighborsRegressor())
+    assert not is_fitted(estimator._wrapped)
+
+    estimator = estimator.fit(X, y)
+    assert is_fitted(estimator._wrapped)
+    assert is_fitted(estimator)


### PR DESCRIPTION
@grovduck, I've been staring at this too long and feel like I'm getting to the point where there's probably some unnecessary complexity left over, but I'm going to start making it worse if I keep working on it! A second set of eyes would be a huge help when you have a chance!

Closes #13 and #14 by switching from a functional API for sklearn methods (currently `predict` and `kneighbors`) to a wrapper estimator. Now instead of calling those functions directly, you can wrap an existing estimator, fit it, and call the estimator's methods with image data, e.g.

```python
from sknnr import GNNRegressor

from sknnr_spatial.datasets import load_swo_ecoplot
from sknnr_spatial import wrap


X_img, X, y = load_swo_ecoplot(as_dataset=True)
est = wrap(GNNRegressor(n_neighbors=7)).fit(X, y)

est.predict(X_img).PSME_COV.plot()
```

Because estimators must be fit *after* wrapping, we can now force consistent outputs with single-output data (#14) by 1) always squeezing single-output to 1D since that produces consistent results with all estimators and 2) storing the number and name of targets used for fitting. This avoids the need to pass `y` data during prediction or try to infer things from the estimator.

Some notes below:

### Naming

The `wrap` function name is 100% a placeholder. Since this function is pretty much the entire public API, it seems like we should give it a good name! 

We could also skip the wrapper function and have users instantiate the `ImageEstimator` directly (also open to naming suggestions there), but I thought that might feel more like you're getting a new estimator type with different methods rather than just a wrapper around your estimator. 

### Non-image data

I added a `check_is_x_image` decorator that falls back to the wrapped sklearn methods for non-image data, so e.g. you can still predict from tabular data with a wrapped estimator. I'm not totally sure that's the right decision, so let me know if you have any thoughts on that.

### Image wrappers instead of single dispatch

The single dispatch system for dispatching sklearn methods to the correct image types was causing some unnecessary duplication in the Dask-backed images that was only going to get worse as we add more sklearn methods (like `transform`). I switched that for an "image wrapper" system that encapsulates the preprocessor and sklearn methods for each image type. I thought about just combining that directly with the preprocessor classes, but I figured they serve somewhat different purposes so it might be better to keep them separate. 

Once again, there's probably a better name than `ImageWrapper` for that class. I feel like I'm currently using "wrapper" in a lot of different ways that might be making things unnecessarily confusing, e.g. the `ImageWrapper` that contains additional functionality for an image, the `EstimatorWrapper` that allows access to the underlying estimator, and the `wrap_image` and `unwrap_image` in the test system that convert between types.

### Incompatible estimator methods

I tried a handful of different approaches to overriding just the relevant methods for a wrapped estimator (e.g. don't implement `kneighbors` for a `RandomForestRegressor`) and never came up with a perfect solution. Programatically assigning methods with `setattr` looked promising, but I never found a way to get that working with Intellisense, which wasn't able to trace which methods got assigned where. I also tried implementing all methods and removing unused ones, but it [doesn't seem possible](https://stackoverflow.com/a/1684267/17707273) to dynamically remove a method from one instance of a class without removing it from the class entirely.

The solution I settled on was the `check_wrapper_implements` decorator that dynamically throws a `NotImplementedError` if you try to call an unsupported method. Unfortunately this means unsupported methods are still visible and documented, but that seemed preferable to the alternative of *not* documenting supported methods. 

### Feature name warnings

No changes here - warnings are still present when fit with feature names.