### PR TITLE
Improve ambiguous type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "numpy",
     "dask[diagnostics,dataframe]",
     "scikit-learn",
+    "typing-extensions",
 ]
 
 [project.optional-dependencies]

--- a/src/sknnr_spatial/datasets/_base.py
+++ b/src/sknnr_spatial/datasets/_base.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Literal, overload
 
 import numpy as np
 import pandas as pd
 from numpy.typing import NDArray
+from typing_extensions import Any, Literal, overload
 
 from sknnr_spatial import __version__
 from sknnr_spatial.datasets._registry import registry

--- a/src/sknnr_spatial/datasets/_base.py
+++ b/src/sknnr_spatial/datasets/_base.py
@@ -64,7 +64,7 @@ def _load_rasters_to_array(file_paths: list[Path]) -> NDArray:
 
 @overload
 def load_swo_ecoplot(
-    as_dataset: Literal[True],
+    as_dataset: Literal[True] = True,
     large_rasters: bool = False,
     chunks: Any = None,
 ) -> tuple[xr.Dataset, pd.DataFrame, pd.DataFrame]: ...
@@ -72,7 +72,7 @@ def load_swo_ecoplot(
 
 @overload
 def load_swo_ecoplot(
-    as_dataset: Literal[False],
+    as_dataset: Literal[False] = False,
     large_rasters: bool = False,
     chunks: Any = None,
 ) -> tuple[NDArray, pd.DataFrame, pd.DataFrame]: ...

--- a/src/sknnr_spatial/datasets/_base.py
+++ b/src/sknnr_spatial/datasets/_base.py
@@ -64,7 +64,7 @@ def _load_rasters_to_array(file_paths: list[Path]) -> NDArray:
 
 @overload
 def load_swo_ecoplot(
-    as_dataset: Literal[True] = True,
+    as_dataset: Literal[True],
     large_rasters: bool = False,
     chunks: Any = None,
 ) -> tuple[xr.Dataset, pd.DataFrame, pd.DataFrame]: ...

--- a/src/sknnr_spatial/datasets/_base.py
+++ b/src/sknnr_spatial/datasets/_base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, overload
 
 import numpy as np
 import pandas as pd
@@ -60,6 +60,22 @@ def _load_rasters_to_array(file_paths: list[Path]) -> NDArray:
             arr = band if arr is None else np.dstack((arr, band))
 
     return arr
+
+
+@overload
+def load_swo_ecoplot(
+    as_dataset: Literal[True],
+    large_rasters: bool = False,
+    chunks: Any = None,
+) -> tuple[xr.Dataset, pd.DataFrame, pd.DataFrame]: ...
+
+
+@overload
+def load_swo_ecoplot(
+    as_dataset: Literal[False],
+    large_rasters: bool = False,
+    chunks: Any = None,
+) -> tuple[NDArray, pd.DataFrame, pd.DataFrame]: ...
 
 
 def load_swo_ecoplot(

--- a/src/sknnr_spatial/estimator.py
+++ b/src/sknnr_spatial/estimator.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING
 from warnings import warn
 
 from sklearn.base import clone
+from typing_extensions import Literal, overload
 
 from .types import EstimatorType
 from .utils.estimator import (

--- a/src/sknnr_spatial/estimator.py
+++ b/src/sknnr_spatial/estimator.py
@@ -159,6 +159,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         self,
         X_image: ImageType,
         *,
+        n_neighbors: int | None = None,
         return_distance: Literal[False] = False,
         nodata_vals: NoDataType = None,
         **kneighbors_kwargs,
@@ -171,6 +172,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         self,
         X_image: ImageType,
         *,
+        n_neighbors: int | None = None,
         return_distance: Literal[True] = True,
         nodata_vals: NoDataType = None,
         **kneighbors_kwargs,
@@ -182,6 +184,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         self,
         X_image: ImageType,
         *,
+        n_neighbors: int | None = None,
         return_distance: bool = True,
         nodata_vals: NoDataType = None,
         **kneighbors_kwargs,
@@ -201,13 +204,18 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         X_image : Numpy or Xarray image with 3 dimensions (y, x, band)
             The input image. Features in the band dimension should correspond with the
             features used to fit the estimator.
+        n_neighbors : int, optional
+            Number of neighbors required for each sample. The default is the value
+            passed to the wrapped estimator's constructor.
+        return_distance : bool, default=True
+            If True, return distances to the neighbors of each sample. If False, return
+            indices only.
         nodata_vals : float or sequence of floats, optional
             NoData values to mask in the output image. A single value will be broadcast
             to all bands while sequences of values will be assigned band-wise. If None,
             values will be inferred if possible based on image metadata.
         **kneighbors_kwargs
-            Additional arguments passed to the estimator's kneighbors method, e.g.
-            `return_distance`.
+            Additional arguments passed to the estimator's kneighbors method.
 
         Returns
         -------
@@ -217,10 +225,13 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         neigh_ind : Numpy or Xarray image with 3 dimensions (y, x, neighbor)
             Indices of the nearest points in the population matrix.
         """
-        kneighbors_kwargs["return_distance"] = return_distance
-
         wrapper = get_image_wrapper(X_image)(X_image, nodata_vals=nodata_vals)
-        return wrapper.kneighbors(estimator=self, **kneighbors_kwargs)
+        return wrapper.kneighbors(
+            estimator=self,
+            n_neighbors=n_neighbors,
+            return_distance=return_distance,
+            **kneighbors_kwargs,
+        )
 
 
 def wrap(estimator: EstimatorType) -> ImageEstimator[EstimatorType]:

--- a/src/sknnr_spatial/estimator.py
+++ b/src/sknnr_spatial/estimator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 from warnings import warn
 
 from sklearn.base import clone
@@ -153,8 +153,37 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
 
     @check_wrapper_implements
     @image_or_fallback
+    @overload
     def kneighbors(
-        self, X_image: ImageType, *, nodata_vals: NoDataType = None, **kneighbors_kwargs
+        self,
+        X_image: ImageType,
+        *,
+        return_distance: Literal[False] = False,
+        nodata_vals: NoDataType = None,
+        **kneighbors_kwargs,
+    ) -> ImageType: ...
+
+    @check_wrapper_implements
+    @image_or_fallback
+    @overload
+    def kneighbors(
+        self,
+        X_image: ImageType,
+        *,
+        return_distance: Literal[True] = True,
+        nodata_vals: NoDataType = None,
+        **kneighbors_kwargs,
+    ) -> tuple[ImageType, ImageType]: ...
+
+    @check_wrapper_implements
+    @image_or_fallback
+    def kneighbors(
+        self,
+        X_image: ImageType,
+        *,
+        return_distance: bool = True,
+        nodata_vals: NoDataType = None,
+        **kneighbors_kwargs,
     ) -> ImageType | tuple[ImageType, ImageType]:
         """
         Find the K-neighbors of each pixel in an image.
@@ -187,6 +216,8 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         neigh_ind : Numpy or Xarray image with 3 dimensions (y, x, neighbor)
             Indices of the nearest points in the population matrix.
         """
+        kneighbors_kwargs["return_distance"] = return_distance
+
         wrapper = get_image_wrapper(X_image)(X_image, nodata_vals=nodata_vals)
         return wrapper.kneighbors(estimator=self, **kneighbors_kwargs)
 

--- a/src/sknnr_spatial/image/_base.py
+++ b/src/sknnr_spatial/image/_base.py
@@ -184,5 +184,7 @@ class ImageWrapper(ABC, Generic[ImageType]):
         self,
         *,
         estimator: ImageEstimator[KNeighborsMixin],
+        n_neighbors: int | None = None,
+        return_distance: bool = True,
         **kneighbors_kwargs,
     ) -> ImageType | tuple[ImageType, ImageType]: ...

--- a/src/sknnr_spatial/image/_dask_backed.py
+++ b/src/sknnr_spatial/image/_dask_backed.py
@@ -71,11 +71,11 @@ class DaskBackedWrapper(ImageWrapper[DaskBackedType]):
         self,
         *,
         estimator: ImageEstimator[KNeighborsMixin],
+        n_neighbors: int | None = None,
+        return_distance: bool = True,
         **kneighbors_kwargs,
     ) -> DaskBackedType | tuple[DaskBackedType, DaskBackedType]:
         """Generic kneighbors wrapper for Dask-backed arrays."""
-        return_distance = kneighbors_kwargs.pop("return_distance", True)
-
         k = estimator.n_neighbors
         var_names = [f"k{i + 1}" for i in range(k)]
 
@@ -91,6 +91,7 @@ class DaskBackedWrapper(ImageWrapper[DaskBackedType]):
             output_dtypes=output_dtypes,
             axis=self.preprocessor.flat_band_dim,
             allow_rechunk=True,
+            n_neighbors=n_neighbors,
             return_distance=return_distance,
             **kneighbors_kwargs,
         )

--- a/src/sknnr_spatial/image/_dask_backed.py
+++ b/src/sknnr_spatial/image/_dask_backed.py
@@ -76,7 +76,8 @@ class DaskBackedWrapper(ImageWrapper[DaskBackedType]):
         **kneighbors_kwargs,
     ) -> DaskBackedType | tuple[DaskBackedType, DaskBackedType]:
         """Generic kneighbors wrapper for Dask-backed arrays."""
-        k = estimator.n_neighbors
+        k = n_neighbors if n_neighbors is not None else estimator.n_neighbors
+
         var_names = [f"k{i + 1}" for i in range(k)]
 
         # Set the expected gufunc output depending on whether distances will be included

--- a/src/sknnr_spatial/image/ndarray.py
+++ b/src/sknnr_spatial/image/ndarray.py
@@ -55,12 +55,13 @@ class NDArrayWrapper(ImageWrapper[NDArray]):
         self,
         *,
         estimator: ImageEstimator[KNeighborsMixin],
+        n_neighbors: int | None = None,
+        return_distance: bool = True,
         **kneighbors_kwargs,
     ) -> NDArray | tuple[NDArray, NDArray]:
-        return_distance = kneighbors_kwargs.pop("return_distance", True)
-
         result = estimator._wrapped.kneighbors(
             self.preprocessor.flat,
+            n_neighbors=n_neighbors,
             return_distance=return_distance,
             **kneighbors_kwargs,
         )

--- a/src/sknnr_spatial/types.py
+++ b/src/sknnr_spatial/types.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any, TypeVar, Union
+from typing import Union
 
 import xarray as xr
 from numpy.typing import NDArray
 from sklearn.base import BaseEstimator
+from typing_extensions import Any, TypeVar
 
 DaskBackedType = TypeVar("DaskBackedType", xr.DataArray, xr.Dataset)
 ImageType = TypeVar("ImageType", NDArray, xr.DataArray, xr.Dataset)

--- a/src/sknnr_spatial/utils/estimator.py
+++ b/src/sknnr_spatial/utils/estimator.py
@@ -1,8 +1,9 @@
 from functools import wraps
-from typing import Callable, Concatenate, Generic, ParamSpec, TypeVar
+from typing import Callable, Generic
 
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import NotFittedError, check_is_fitted
+from typing_extensions import Concatenate, ParamSpec, TypeVar
 
 from ..image._base import ImageType
 from ..types import AnyType

--- a/src/sknnr_spatial/utils/estimator.py
+++ b/src/sknnr_spatial/utils/estimator.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Callable, Generic
+from typing import Callable, Concatenate, Generic, ParamSpec, TypeVar
 
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import NotFittedError, check_is_fitted
@@ -7,6 +7,9 @@ from sklearn.utils.validation import NotFittedError, check_is_fitted
 from ..image._base import ImageType
 from ..types import AnyType
 from .image import is_image_type
+
+RT = TypeVar("RT")
+P = ParamSpec("P")
 
 
 class AttrWrapper(Generic[AnyType]):
@@ -25,7 +28,15 @@ class AttrWrapper(Generic[AnyType]):
         return self._wrapped.__dict__
 
 
-def check_wrapper_implements(func: Callable) -> Callable:
+# Callable that takes an AttrWrapper instance and other generic parameters and returns a
+# generic type.
+GenericWrappedCallable = Callable[Concatenate[AttrWrapper, P], RT]
+# Callable that takes an AttrWrapper instance, an ImageType, and other generic
+# parameters and returns a generic type.
+GenericWrappedImageCallable = Callable[Concatenate[AttrWrapper, ImageType, P], RT]
+
+
+def check_wrapper_implements(func: GenericWrappedCallable) -> GenericWrappedCallable:
     """Decorator that raises if the wrapped instance doesn't implement the method."""
 
     @wraps(func)
@@ -40,7 +51,7 @@ def check_wrapper_implements(func: Callable) -> Callable:
     return wrapper
 
 
-def image_or_fallback(func: Callable) -> Callable:
+def image_or_fallback(func: GenericWrappedImageCallable) -> GenericWrappedImageCallable:
     """Decorator that calls the wrapped method for non-image X arrays."""
 
     @wraps(func)

--- a/src/sknnr_spatial/utils/image.py
+++ b/src/sknnr_spatial/utils/image.py
@@ -1,7 +1,6 @@
-from typing import Any
-
 import numpy as np
 import xarray as xr
+from typing_extensions import Any
 
 from ..image._base import ImageType, ImageWrapper
 from ..image.dataarray import DataArrayWrapper

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,10 +1,10 @@
 import pickle
 import sys
 from dataclasses import dataclass
-from typing import Any
 from unittest import mock
 
 import pytest
+from typing_extensions import Any
 
 from sknnr_spatial.datasets import load_swo_ecoplot
 

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -98,6 +98,22 @@ def test_kneighbors_without_distance(dummy_model_data, image_type, k):
 
 
 @parametrize_image_types
+@pytest.mark.parametrize("n_neighbors", [1, 5], ids=lambda k: f"n_neighbors={k}")
+def test_kneighbors_with_n_neighbors(dummy_model_data, image_type, n_neighbors):
+    """Test kneighbors returns n_neighbors when specified."""
+    X_image, X, y = dummy_model_data
+    estimator = wrap(KNeighborsRegressor(n_neighbors=3)).fit(X, y)
+
+    X_wrapped = wrap_image(X_image, type=image_type.cls)
+    nn = estimator.kneighbors(X_wrapped, n_neighbors=n_neighbors, return_distance=False)
+    nn = unwrap_image(nn)
+
+    assert nn.ndim == 3
+
+    assert_array_equal(nn.shape, (X_image.shape[0], X_image.shape[1], n_neighbors))
+
+
+@parametrize_image_types
 @pytest.mark.parametrize("k", [1, 3], ids=lambda k: f"k{k}")
 def test_kneighbors_unsupervised(dummy_model_data, image_type, k):
     """Test kneighbors works with all image types when unsupervised."""


### PR DESCRIPTION
I noticed some ambiguous types being inferred in VS Code during usage, so I spent a little time trying to improve those. That basically boiled down to:

1. Using [`@overload`](https://adamj.eu/tech/2021/05/29/python-type-hints-how-to-use-overload/) to specify return types that depend on input parameters and
2. Using some [PEP 612](https://peps.python.org/pep-0612/) magic to prevent type annotations getting lost by the decorators.

To demonstrate, here are the inferred types in grey (activated with the `python.analysis.inlayHints.variableTypes` setting in VS Code) before the typing changes:
![type_annotations_main](https://github.com/lemma-osu/sknnr-spatial/assets/50475791/9a6f7824-8235-42dd-b44e-d48331791242)

And after:
![type_annotations_fixed](https://github.com/lemma-osu/sknnr-spatial/assets/50475791/de9d1daa-f2fa-495e-89fd-93f45807a72b)

Aside from adding some code complexity, the downside of these changes that I realized too late is that PEP 612 wasn't implemented until Python 3.10, so I had to temporarily add [`typing-extensions`](https://github.com/python/typing_extensions) (an official backport of new typing features) as a dependency so that we can continue supporting 3.9. Once we eventually drop 3.9, we could also drop `typing-extensions`. 

The other alternatives would be to hold off on this PR or drop 3.9 support now. The Numpy support schedule recommended dropping 3.9 support a couple months ago, so that's probably not unreasonable, but it does feel a little restrictive considering we don't have any older releases for compatibility. Let me know if you have any strong feelings either way @grovduck!