### PR TITLE
Implement feature name checking

### DIFF
--- a/src/sknnr_spatial/estimator.py
+++ b/src/sknnr_spatial/estimator.py
@@ -4,7 +4,9 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from warnings import warn
 
+import numpy as np
 from sklearn.base import clone
+from sklearn.utils.validation import _get_feature_names, check_is_fitted
 from typing_extensions import Literal, overload
 
 from .types import EstimatorType
@@ -17,8 +19,8 @@ from .utils.estimator import (
 from .utils.image import get_image_wrapper
 
 if TYPE_CHECKING:
-    import numpy as np
     import pandas as pd
+    from numpy.typing import NDArray
 
     from .types import ImageType, NoDataType
 
@@ -29,6 +31,7 @@ class FittedMetadata:
 
     n_targets: int
     target_names: tuple[str | int, ...]
+    feature_names: NDArray
 
 
 class ImageEstimator(AttrWrapper[EstimatorType]):
@@ -112,11 +115,17 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             # to (n_samples,), which has a consistent output shape.
             y = y.squeeze()
 
-        self._wrapped = self._wrapped.fit(X, y, **kwargs)
+        # Cast X to array before fitting to prevent the estimator from storing feature
+        # names. We implement our own feature name checks that are image-compatible.
+        self._wrapped = self._wrapped.fit(np.asarray(X), y, **kwargs)
+        fitted_feature_names = _get_feature_names(X)
 
         self._wrapped_meta = FittedMetadata(
             n_targets=self._get_n_targets(y),
             target_names=self._get_target_names(y),
+            feature_names=fitted_feature_names
+            if fitted_feature_names is not None
+            else np.array([]),
         )
 
         return self
@@ -150,6 +159,8 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             The predicted values.
         """
         wrapper = get_image_wrapper(X_image)(X_image, nodata_vals=nodata_vals)
+        self._check_feature_names(wrapper.preprocessor.band_names)
+
         return wrapper.predict(estimator=self)
 
     @check_wrapper_implements
@@ -226,12 +237,73 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             Indices of the nearest points in the population matrix.
         """
         wrapper = get_image_wrapper(X_image)(X_image, nodata_vals=nodata_vals)
+        self._check_feature_names(wrapper.preprocessor.band_names)
+
         return wrapper.kneighbors(
             estimator=self,
             n_neighbors=n_neighbors,
             return_distance=return_distance,
             **kneighbors_kwargs,
         )
+
+    def _check_feature_names(self, image_feature_names: NDArray) -> None:
+        """Check that image feature names match feature names seen during fitting."""
+        check_is_fitted(self._wrapped)
+        fitted_feature_names = self._wrapped_meta.feature_names
+
+        no_fitted_names = len(fitted_feature_names) == 0
+        no_image_names = len(image_feature_names) == 0
+
+        if no_fitted_names and no_image_names:
+            return
+
+        if no_fitted_names:
+            warn(
+                f"X_image has feature names, but {self._wrapped.__class__.__name__} was"
+                " fitted without feature names",
+                stacklevel=2,
+            )
+            return
+
+        if no_image_names:
+            warn(
+                "X_image does not have valid feature names, but"
+                f" {self._wrapped.__class__.__name__} was fitted with feature names",
+                stacklevel=2,
+            )
+            return
+
+        if len(fitted_feature_names) != len(image_feature_names) or np.any(
+            fitted_feature_names != image_feature_names
+        ):
+            msg = "Image band names should match those that were passed during fit.\n"
+            fitted_feature_names_set = set(fitted_feature_names)
+            image_feature_names_set = set(image_feature_names)
+
+            unexpected_names = sorted(
+                image_feature_names_set - fitted_feature_names_set
+            )
+            missing_names = sorted(fitted_feature_names_set - image_feature_names_set)
+
+            def add_names(names):
+                max_n_names = 5
+                if len(names) > max_n_names:
+                    names = [*names[: max_n_names + 1], "..."]
+
+                return "".join([f"- {name}\n" for name in names])
+
+            if unexpected_names:
+                msg += "Band names unseen at fit time:\n"
+                msg += add_names(unexpected_names)
+
+            if missing_names:
+                msg += "Band names seen at fit time, yet now missing:\n"
+                msg += add_names(missing_names)
+
+            if not missing_names and not unexpected_names:
+                msg += "Band names must be in the same order as they were in fit.\n"
+
+            raise ValueError(msg)
 
 
 def wrap(estimator: EstimatorType) -> ImageEstimator[EstimatorType]:

--- a/src/sknnr_spatial/estimator.py
+++ b/src/sknnr_spatial/estimator.py
@@ -329,13 +329,13 @@ def wrap(estimator: EstimatorType) -> ImageEstimator[EstimatorType]:
 
     >>> from sklearn.neighbors import KNeighborsRegressor
     >>> from sknnr_spatial.datasets import load_swo_ecoplot
-    >>> X_img, X, y = load_swo_ecoplot()
+    >>> X_img, X, y = load_swo_ecoplot(as_dataset=True)
     >>> est = wrap(KNeighborsRegressor(n_neighbors=3)).fit(X, y)
 
     Use a wrapped estimator to predict from image data stored in Numpy or Xarray arrays:
 
     >>> pred = est.predict(X_img)
-    >>> pred.shape
-    (128, 128, 25)
+    >>> pred.PSME_COV.shape
+    (128, 128)
     """
     return ImageEstimator(estimator)

--- a/src/sknnr_spatial/estimator.py
+++ b/src/sknnr_spatial/estimator.py
@@ -64,7 +64,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
 
         return estimator
 
-    def _get_n_targets(self, y: np.ndarray | pd.DataFrame | pd.Series | None) -> int:
+    def _get_n_targets(self, y: NDArray | pd.DataFrame | pd.Series | None) -> int:
         """Get the number of targets used to fit the estimator."""
         # Unsupervised and single-output estimators should both return a single target
         if y is None or y.ndim == 1:
@@ -73,7 +73,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         return y.shape[-1]
 
     def _get_target_names(
-        self, y: np.ndarray | pd.DataFrame | pd.Series
+        self, y: NDArray | pd.DataFrame | pd.Series
     ) -> tuple[str | int, ...]:
         """Get the target names used to fit the estimator, if available."""
         # Dataframe

--- a/src/sknnr_spatial/estimator.py
+++ b/src/sknnr_spatial/estimator.py
@@ -267,7 +267,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
 
         if no_image_names:
             warn(
-                "X_image does not have valid feature names, but"
+                "X_image does not have feature names, but"
                 f" {self._wrapped.__class__.__name__} was fitted with feature names",
                 stacklevel=2,
             )

--- a/src/sknnr_spatial/image/_base.py
+++ b/src/sknnr_spatial/image/_base.py
@@ -66,6 +66,7 @@ class ImagePreprocessor(ABC):
 
     band_dim: int
     flat_band_dim = -1
+    band_names: NDArray
 
     def __init__(
         self,

--- a/src/sknnr_spatial/image/dataarray.py
+++ b/src/sknnr_spatial/image/dataarray.py
@@ -21,6 +21,11 @@ class DataArrayPreprocessor(ImagePreprocessor):
     _backend = da
     band_dim = 0
 
+    @property
+    def band_names(self) -> NDArray:
+        band_dim_name = self.image.dims[self.band_dim]
+        return self.image[band_dim_name].values
+
     def _validate_nodata_vals(self, nodata_vals: NoDataType) -> NDArray | None:
         """
         Get an array of NoData values in the shape (bands,) based on user input and

--- a/src/sknnr_spatial/image/ndarray.py
+++ b/src/sknnr_spatial/image/ndarray.py
@@ -43,7 +43,6 @@ class NDArrayWrapper(ImageWrapper[NDArray]):
         estimator: ImageEstimator[BaseEstimator],
     ) -> NDArray:
         """Predict attributes from an array of X_image."""
-        # TODO: Deal with sklearn warning about missing feature names
         y_pred_flat = estimator._wrapped.predict(self.preprocessor.flat)
 
         # Reshape from (n_samples,) to (n_samples, 1)

--- a/src/sknnr_spatial/image/ndarray.py
+++ b/src/sknnr_spatial/image/ndarray.py
@@ -19,6 +19,7 @@ class NDArrayPreprocessor(ImagePreprocessor):
 
     _backend = np
     band_dim = -1
+    band_names = np.array([])
 
     def _flatten(self, image: NDArray) -> NDArray:
         """Flatten the array from (y, x, bands) to (pixels, bands)."""

--- a/src/sknnr_spatial/utils/image.py
+++ b/src/sknnr_spatial/utils/image.py
@@ -2,7 +2,7 @@ import numpy as np
 import xarray as xr
 from typing_extensions import Any
 
-from ..image._base import ImageType, ImageWrapper
+from ..image._base import ImagePreprocessor, ImageType, ImageWrapper
 from ..image.dataarray import DataArrayWrapper
 from ..image.dataset import DatasetWrapper
 from ..image.ndarray import NDArrayWrapper
@@ -30,3 +30,8 @@ def get_image_wrapper(X_image: ImageType) -> type[ImageWrapper]:
         return DatasetWrapper
 
     raise TypeError(f"Unsupported image type: {type(X_image).__name__}")
+
+
+def get_image_preprocessor(X_image: ImageType) -> type[ImagePreprocessor]:
+    """Get an ImagePreprocessor subclass for a given image."""
+    return get_image_wrapper(X_image).preprocessor_cls

--- a/tests/image_utils.py
+++ b/tests/image_utils.py
@@ -1,71 +1,212 @@
-"""
-Image wrappers used for testing various image types with a common Numpy NDArray
-interface.
+from __future__ import annotations
 
-An example usage is shown below, where an array is wrapped into an Xarray image,
-modified, unwrapped back to a Numpy array, and compared to another array.
-
->>> from numpy.testing import assert_array_equal
->>> array = np.ones((8, 8, 3))
->>> wrapped = wrap_image(np.ones((8, 8, 3)), type=xr.Dataset)
->>> wrapped += 1
->>> assert_array_equal(unwrap_image(wrapped), array + 1)
-
-The advantage of this system is that you can easily parameterize over multiple types by
-changing the `type` parameter, without having to modify the test code.
-"""
-
-from dataclasses import dataclass
 from functools import singledispatch
+from typing import Generic
 
 import dask.array as da
 import numpy as np
+import pandas as pd
 import pytest
 import xarray as xr
 from numpy.typing import NDArray
 
-from sknnr_spatial.image._base import ImagePreprocessor
-from sknnr_spatial.image.dataarray import DataArrayPreprocessor
-from sknnr_spatial.image.dataset import DatasetPreprocessor
-from sknnr_spatial.image.ndarray import NDArrayPreprocessor
 from sknnr_spatial.types import ImageType
 
-
-@dataclass
-class TestImageType:
-    """A container for image types used in testing."""
-
-    __test__ = False
-    cls: type[ImageType]
-    preprocessor: type[ImagePreprocessor]
-
-    @property
-    def name(self):
-        return self.cls.__name__
-
-
+# Parametrize over all supported image types
 parametrize_image_types = pytest.mark.parametrize(
     "image_type",
     [
-        TestImageType(np.ndarray, NDArrayPreprocessor),
-        TestImageType(xr.DataArray, DataArrayPreprocessor),
-        TestImageType(xr.Dataset, DatasetPreprocessor),
+        np.ndarray,
+        xr.DataArray,
+        xr.Dataset,
     ],
-    ids=lambda t: t.name,
+    ids=lambda t: t.__name__,
 )
 
-parametrize_xarray_image_types = pytest.mark.parametrize(
-    "image_type",
-    [
-        TestImageType(xr.DataArray, DataArrayPreprocessor),
-        TestImageType(xr.Dataset, DatasetPreprocessor),
-    ],
-    ids=lambda t: t.name,
-)
+
+class ModelData(Generic[ImageType]):
+    """
+    Data used to train and predict with image-compatible estimators for testing.
+
+    Examples
+    --------
+    ModelData is designed to be instantiated with Numpy array data and unpacked to
+    retrieve compatible images and training data.
+
+    >>> X_image = np.random.random((16, 16, 5))
+    >>> X = np.random.random((10, 5))
+    >>> y = np.random.random((10, 3))
+    >>> model_data = ModelData(X_image, X, y, image_type=xr.Dataset)
+    >>> X_image, X, y = model_data
+    >>> type(X_image)
+    <class 'xarray.core.dataset.Dataset'>
+    >>> type(y)
+    <class 'pandas.core.frame.DataFrame'>
+
+    Data is generated on-the-fly, so you can mutate the ModelData with `set` and then
+    retrieve new data.
+
+    >>> y.shape
+    (10, 3)
+    >>> _, _, y = model_data.set(single_output=True, squeeze=True)
+    >>> y.shape
+    (10,)
+    """
+
+    def __init__(
+        self,
+        X_image: NDArray,
+        X: NDArray,
+        y: NDArray,
+        image_type: type[ImageType] = np.ndarray,
+    ):
+        self._image_type = image_type
+        self._X_image = X_image
+        self._X = X
+        self._y = y
+        self._single_output = False
+        self._squeeze = False
+
+    def __iter__(self):
+        """Unpack the data into (X_image, X, y)."""
+        return iter((self.X_image, self.X, self.y))
+
+    @property
+    def n_targets(self):
+        return self._y.shape[-1]
+
+    @property
+    def n_rows(self):
+        return self._X_image.shape[0]
+
+    @property
+    def n_cols(self):
+        return self._X_image.shape[1]
+
+    @property
+    def n_features(self):
+        return self._X_image.shape[-1]
+
+    @property
+    def X_image(self) -> ImageType:
+        """Feature image."""
+        return wrap_image(self._X_image, self._image_type)
+
+    @property
+    def X(self) -> NDArray | pd.DataFrame:
+        """Feature data in array or dataframe format."""
+        X = self._X.copy()
+
+        if self._image_type in (xr.DataArray, xr.Dataset):
+            band_names = [f"b{i}" for i in range(self.n_features)]
+            X = pd.DataFrame(X, columns=band_names)
+
+        return X
+
+    @property
+    def y(self) -> NDArray | pd.DataFrame:
+        """Label data in array or dataframe format."""
+        y = self._y.copy()
+
+        n_targets = self.n_targets
+        if self._single_output:
+            y = y[:, :1]
+            n_targets = 1
+
+        if self._image_type in (xr.DataArray, xr.Dataset):
+            target_names = [f"t{i}" for i in range(n_targets)]
+            y = pd.DataFrame(y, columns=target_names)
+
+        if self._squeeze:
+            y = y.squeeze()
+
+        return y
+
+    def set(self, **kwargs):
+        """
+        Update the ModelData's attributes.
+
+        Attributes should be referenced by their public names, e.g. `X_image`, but
+        will actually update corresponding private attributes to avoid shadowing public
+        properties.
+        """
+        for k, v in kwargs.items():
+            if k.startswith("_"):
+                msg = (
+                    "Set attributes based on their public names, e.g. `X_image` "
+                    "instead of `_X_image`."
+                )
+                raise ValueError(msg)
+
+            # Attributes are all stored with a leading underscore to avoid shadowing
+            # public properties.
+            k = f"_{k}"
+
+            if not hasattr(self, k):
+                raise AttributeError(f"{k} is not a valid property of ModelData.")
+
+            setattr(self, k, v)
+
+        return self
+
+
+def parametrize_model_data(
+    label="model_data",
+    X_image=None,
+    X=None,
+    y=None,
+    image_types=(np.ndarray, xr.DataArray, xr.Dataset),
+):
+    """Parametrize over multiple image types with the same test data."""
+    n_features = (
+        X_image.shape[-1]
+        if X_image is not None
+        else X.shape[-1]
+        if X is not None
+        else 5
+    )
+    n_targets = y.shape[-1] if y is not None else 3
+    n_rows = X.shape[0] if X is not None else y.shape[0] if y is not None else 10
+
+    # Default test data
+    if X_image is None:
+        X_image = np.random.rand(8, 16, n_features)
+    if X is None:
+        X = np.random.rand(n_rows, n_features)
+    if y is None:
+        y = np.random.rand(n_rows, n_targets)
+
+    model_data = [ModelData(X_image, X, y, cls) for cls in image_types]
+
+    return pytest.mark.parametrize(
+        label, model_data, ids=map(lambda x: x.__name__, image_types)
+    )
 
 
 def wrap_image(image: NDArray, type: type[ImageType]) -> ImageType:
-    """Wrap a Numpy NDArray image (y, x, bands) into the specified type."""
+    """
+    Wrap a Numpy NDArray image (y, x, bands) into the specified type.
+
+    Examples
+    --------
+
+    Wrap a Numpy array into a desired image type:
+
+    >>> array = np.ones((8, 8, 3))
+    >>> wrapped = wrap_image(array, type=xr.DataArray)
+    >>> type(wrapped)
+    <class 'xarray.core.dataarray.DataArray'>
+
+    Combine with `unwrap_image` to allow testing functions that are compatible with any
+    image type:
+
+    >>> from numpy.testing import assert_array_equal
+    >>> array = np.ones((8, 8, 3))
+    >>> wrapped = wrap_image(array, type=xr.Dataset)
+    >>> wrapped += 1
+    >>> assert_array_equal(unwrap_image(wrapped), array + 1)
+    """
+
     if type is np.ndarray:
         return image
 

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -11,162 +11,157 @@ from sklearn.utils.validation import NotFittedError
 
 from sknnr_spatial import wrap
 
-from .image_utils import (
-    parametrize_image_types,
-    parametrize_xarray_image_types,
-    unwrap_image,
-    wrap_image,
-)
+from .image_utils import parametrize_model_data, unwrap_image
 
 
-@parametrize_image_types
+@parametrize_model_data()
 @pytest.mark.parametrize("estimator", [KNeighborsRegressor, RandomForestRegressor])
 @pytest.mark.parametrize("single_output", [True, False], ids=["single", "multi"])
 @pytest.mark.parametrize("squeeze", [True, False], ids=["squeezed", "unsqueezed"])
-def test_predict(dummy_model_data, image_type, estimator, single_output, squeeze):
+def test_predict(model_data, estimator, single_output, squeeze):
     """Test that predict works with all image types and a few estimators."""
-    X_image, X, y = dummy_model_data
-
-    if single_output:
-        y = y[:, :1]
-    if squeeze:
-        y = y.squeeze()
+    X_image, X, y = model_data.set(single_output=single_output, squeeze=squeeze)
 
     estimator = wrap(estimator()).fit(X, y)
 
-    X_wrapped = wrap_image(X_image, type=image_type.cls)
-    y_pred = unwrap_image(estimator.predict(X_wrapped))
+    y_pred = unwrap_image(estimator.predict(X_image))
 
     assert y_pred.ndim == 3
     expected_shape = (
-        X_image.shape[0],
-        X_image.shape[1],
-        1 if single_output else y.shape[-1],
+        model_data.n_rows,
+        model_data.n_cols,
+        1 if single_output else model_data.n_targets,
     )
     assert_array_equal(y_pred.shape, expected_shape)
 
 
-@parametrize_image_types
+@parametrize_model_data()
 @pytest.mark.parametrize("estimator", [KMeans, MeanShift, AffinityPropagation])
-def test_predict_unsupervised(dummy_model_data, image_type, estimator):
+def test_predict_unsupervised(model_data, estimator):
     """Test that predict works with all image types with unsupervised estimators."""
-    X_image, X, _ = dummy_model_data
+    X_image, X, _ = model_data
 
     estimator = wrap(estimator()).fit(X)
 
-    X_wrapped = wrap_image(X_image, type=image_type.cls)
-    y_pred = unwrap_image(estimator.predict(X_wrapped))
+    y_pred = unwrap_image(estimator.predict(X_image))
 
     assert y_pred.ndim == 3
-    expected_shape = (X_image.shape[0], X_image.shape[1], 1)
+    expected_shape = (model_data.n_rows, model_data.n_cols, 1)
     assert_array_equal(y_pred.shape, expected_shape)
 
 
-@parametrize_image_types
+@parametrize_model_data()
 @pytest.mark.parametrize("k", [1, 3], ids=lambda k: f"k{k}")
-def test_kneighbors_with_distance(dummy_model_data, image_type, k):
+def test_kneighbors_with_distance(model_data, k):
     """Test kneighbors works with all image types when returning distance."""
-    X_image, X, y = dummy_model_data
+    X_image, X, y = model_data
+
     estimator = wrap(KNeighborsRegressor(n_neighbors=k)).fit(X, y)
 
-    X_wrapped = wrap_image(X_image, type=image_type.cls)
-    dist, nn = estimator.kneighbors(X_wrapped, return_distance=True)
+    dist, nn = estimator.kneighbors(X_image, return_distance=True)
     dist = unwrap_image(dist)
     nn = unwrap_image(nn)
 
     assert dist.ndim == 3
     assert nn.ndim == 3
 
-    assert_array_equal(dist.shape, (X_image.shape[0], X_image.shape[1], k))
-    assert_array_equal(nn.shape, (X_image.shape[0], X_image.shape[1], k))
+    assert_array_equal(dist.shape, (model_data.n_rows, model_data.n_cols, k))
+    assert_array_equal(nn.shape, (model_data.n_rows, model_data.n_cols, k))
 
 
-@parametrize_image_types
+@parametrize_model_data()
 @pytest.mark.parametrize("k", [1, 3], ids=lambda k: f"k{k}")
-def test_kneighbors_without_distance(dummy_model_data, image_type, k):
+def test_kneighbors_without_distance(model_data, k):
     """Test kneighbors works with all image types when NOT returning distance."""
-    X_image, X, y = dummy_model_data
+    X_image, X, y = model_data
     estimator = wrap(KNeighborsRegressor(n_neighbors=k)).fit(X, y)
 
-    X_wrapped = wrap_image(X_image, type=image_type.cls)
-    nn = estimator.kneighbors(X_wrapped, return_distance=False)
+    nn = estimator.kneighbors(X_image, return_distance=False)
     nn = unwrap_image(nn)
 
     assert nn.ndim == 3
 
-    assert_array_equal(nn.shape, (X_image.shape[0], X_image.shape[1], k))
+    assert_array_equal(nn.shape, (model_data.n_rows, model_data.n_cols, k))
 
 
-@parametrize_image_types
+@parametrize_model_data()
 @pytest.mark.parametrize("n_neighbors", [1, 5], ids=lambda k: f"n_neighbors={k}")
-def test_kneighbors_with_n_neighbors(dummy_model_data, image_type, n_neighbors):
+def test_kneighbors_with_n_neighbors(model_data, n_neighbors):
     """Test kneighbors returns n_neighbors when specified."""
-    X_image, X, y = dummy_model_data
+    X_image, X, y = model_data
+
     estimator = wrap(KNeighborsRegressor(n_neighbors=3)).fit(X, y)
 
-    X_wrapped = wrap_image(X_image, type=image_type.cls)
-    nn = estimator.kneighbors(X_wrapped, n_neighbors=n_neighbors, return_distance=False)
+    nn = estimator.kneighbors(X_image, n_neighbors=n_neighbors, return_distance=False)
     nn = unwrap_image(nn)
 
     assert nn.ndim == 3
 
-    assert_array_equal(nn.shape, (X_image.shape[0], X_image.shape[1], n_neighbors))
+    assert_array_equal(nn.shape, (model_data.n_rows, model_data.n_cols, n_neighbors))
 
 
-@parametrize_image_types
+@parametrize_model_data()
 @pytest.mark.parametrize("k", [1, 3], ids=lambda k: f"k{k}")
-def test_kneighbors_unsupervised(dummy_model_data, image_type, k):
+def test_kneighbors_unsupervised(model_data, k):
     """Test kneighbors works with all image types when unsupervised."""
-    X_image, X, _ = dummy_model_data
+    X_image, X, y = model_data
+
     estimator = wrap(NearestNeighbors(n_neighbors=k)).fit(X)
 
-    X_wrapped = wrap_image(X_image, type=image_type.cls)
-    dist, nn = estimator.kneighbors(X_wrapped, return_distance=True)
+    dist, nn = estimator.kneighbors(X_image, return_distance=True)
     dist = unwrap_image(dist)
     nn = unwrap_image(nn)
 
     assert dist.ndim == 3
     assert nn.ndim == 3
 
-    assert_array_equal(dist.shape, (X_image.shape[0], X_image.shape[1], k))
-    assert_array_equal(nn.shape, (X_image.shape[0], X_image.shape[1], k))
+    assert_array_equal(dist.shape, (model_data.n_rows, model_data.n_cols, k))
+    assert_array_equal(nn.shape, (model_data.n_rows, model_data.n_cols, k))
 
 
-def test_predict_dataarray_with_custom_dim_name(dummy_model_data):
+@parametrize_model_data(image_types=(xr.DataArray,))
+def test_predict_dataarray_with_custom_dim_name(model_data):
     """Test that predict works if the band dimension is not named "variable"."""
-    X_image, X, y = dummy_model_data
+    X_image, X, y = model_data
+
     estimator = wrap(KNeighborsRegressor()).fit(X, y)
-    X_wrapped = wrap_image(X_image, type=xr.DataArray).rename({"variable": "band"})
+    X_image = X_image.rename({"variable": "band"})
 
-    y_pred = unwrap_image(estimator.predict(X_wrapped))
+    y_pred = unwrap_image(estimator.predict(X_image))
     assert y_pred.ndim == 3
-    assert_array_equal(y_pred.shape, (X_image.shape[0], X_image.shape[1], y.shape[-1]))
+    assert_array_equal(
+        y_pred.shape, (model_data.n_rows, model_data.n_cols, model_data.n_targets)
+    )
 
 
-@parametrize_xarray_image_types
+@parametrize_model_data(image_types=(xr.DataArray, xr.Dataset))
 @pytest.mark.parametrize("crs", ["EPSG:5070", None])
-def test_crs_preserved(dummy_model_data, image_type, crs):
+def test_crs_preserved(model_data, crs):
     """Test that the original image CRS is preserved."""
+    # rioxarray must be imported to register the rio accessor
     import rioxarray  # noqa: F401
 
-    X_image, X, y = dummy_model_data
+    X_image, X, y = model_data
+
     estimator = wrap(KNeighborsRegressor()).fit(X, y)
-    X_wrapped = wrap_image(X_image, type=image_type.cls)
 
     if crs:
-        X_wrapped = X_wrapped.rio.write_crs(crs)
+        X_image = X_image.rio.write_crs(crs)
 
-    y_pred = estimator.predict(X_wrapped)
-    dist, nn = estimator.kneighbors(X_wrapped, return_distance=True)
+    y_pred = estimator.predict(X_image)
+    dist, nn = estimator.kneighbors(X_image, return_distance=True)
 
-    assert y_pred.rio.crs == crs
-    assert dist.rio.crs == crs
-    assert nn.rio.crs == crs
+    if not isinstance(y_pred, np.ndarray):
+        assert y_pred.rio.crs == crs
+        assert dist.rio.crs == crs
+        assert nn.rio.crs == crs
 
 
-def test_with_non_image_data(dummy_model_data):
+@parametrize_model_data(image_types=(np.ndarray,))
+def test_with_non_image_data(model_data):
     """Test that non-image data falls back to the wrapped estimator behavior."""
-    _, X, y = dummy_model_data
+    _, X, y = model_data
+
     estimator = KNeighborsRegressor().fit(X, y)
     reference_pred = estimator.predict(X)
     ref_dist, ref_nn = estimator.kneighbors(X)
@@ -180,39 +175,41 @@ def test_with_non_image_data(dummy_model_data):
     assert_array_equal(ref_nn, check_nn)
 
 
-@parametrize_xarray_image_types
+@parametrize_model_data(image_types=(xr.DataArray, xr.Dataset))
 @pytest.mark.parametrize(
     "fit_with", [np.ndarray, pd.DataFrame, pd.Series], ids=lambda x: x.__name__
 )
-def test_predicted_var_names(dummy_model_data, image_type, fit_with):
+def test_predicted_var_names(model_data, fit_with):
     """Test that variable names are correctly set in a Dataset or DataArray."""
-    X_image, X, y = dummy_model_data
+    X_image, X, y = model_data
 
+    # Models fitted without named targets should predict sequential integer names
     if fit_with is np.ndarray:
         expected_var_names = [0, 1, 2]
-    elif fit_with in [pd.DataFrame, pd.Series]:
-        expected_var_names = ["A", "B", "C"]
-        y = pd.DataFrame(y, columns=expected_var_names)
-
-        if fit_with is pd.Series:
-            y = y["A"]
-            expected_var_names = ["A"]
+        y = np.asarray(y)
+    # Models fitted with multiple target names should predict those names
+    elif fit_with is pd.DataFrame:
+        expected_var_names = ["t0", "t1", "t2"]
+    # Models fitted with a single named series should predict that name
+    elif fit_with is pd.Series:
+        expected_var_names = ["t0"]
+        y = y["t0"]
 
     estimator = wrap(KNeighborsRegressor()).fit(X, y)
-    X_wrapped = wrap_image(X_image, type=image_type.cls)
+    y_pred = estimator.predict(X_image)
 
-    y_pred = estimator.predict(X_wrapped)
-    if image_type.cls is xr.DataArray:
+    if isinstance(X_image, xr.DataArray):
         var_names = y_pred["variable"].values
-    elif image_type.cls is xr.Dataset:
+    else:
         var_names = y_pred.data_vars
 
     assert list(var_names) == expected_var_names
 
 
-def test_raises_if_not_fitted(dummy_model_data):
+@parametrize_model_data()
+def test_raises_if_not_fitted(model_data):
     """Test that wrapped methods raise correctly if the estimator is not fitted."""
-    X_image, _, _ = dummy_model_data
+    X_image, _, _ = model_data
     estimator = KNeighborsRegressor()
     wrapped = wrap(estimator)
 


### PR DESCRIPTION
This closes #17 by 1) bypassing the `sklearn` feature name checks and 2) implementing our own feature name checks that are compatible with images. This also required reworking a large number of tests that would now throw warnings due to mismatched feature names.

This turned out to be trickier than I was hoping, so I've outlined the problem, solution, other solutions I considered, and changes made for testing below.

## The Problem

When an estimator is used to predict new data, `sklearn` compares the feature names that were seen during fitting with the feature names of the new data and raises warnings for missing feature names or errors for mismatched feature names. This is a useful feature as it can catch user errors, but was not compatible with our estimator wrappers which convert images with feature names into flat arrays without feature names. As a result, estimators fit with dataframes would always warn because image feature names were being lost. At the same time, actual mismatched feature names would be ignored for the same reason.  

## The Solution

To avoid incorrect `sklearn` warnings, [we now cast](https://github.com/lemma-osu/sknnr-spatial/pull/23/files#diff-3f81485b1866e6aad777210982a836b046938536d7a8b52bcc049a7aac548084R118-R120) all `X` inputs to NDArrays prior to fitting to remove feature names. All `sklearn` feature name checks will now pass silently because it is unaware that there were ever feature names.

To implement the correct checks, we 1) [store feature names](https://github.com/lemma-osu/sknnr-spatial/pull/23/files#diff-3f81485b1866e6aad777210982a836b046938536d7a8b52bcc049a7aac548084R126-R128) from `X`, if present, and 2) compare those names to image feature names using [`ImageEstimator._check_feature_names`](https://github.com/lemma-osu/sknnr-spatial/pull/23/files#diff-3f81485b1866e6aad777210982a836b046938536d7a8b52bcc049a7aac548084R249). Parsing image feature names is [handled by the image preprocessors](https://github.com/lemma-osu/sknnr-spatial/pull/23/files#diff-5376a04ecba67dd2c160e91d36c61c7625696631d9743d2b4e461424f0ca91e0R24-R27). The feature name checking logic is adapted from [`sklearn.BaseEstimator._check_feature_names`](https://github.com/scikit-learn/scikit-learn/blob/72a604975102b2d93082385d7a5a7033886cc825/sklearn/base.py#L408).

Having to re-implement the feature name checking was not my first choice, but it turned out to be the only solution I could come up with after trying a number of other options below.

## Alternative Solutions

### Using Dask DataFrames

In #17 I proposed using `to_dask_dataframe` prior to prediction, which would theoretically have allowed `sklearn` checks to function as designed with no additional work. What I forgot is that we rely on `dask.array.apply_gufunc` to parallelize all of our operations, which cannot work with dataframes. The dataframe-compatible method of [`dask.DataFrame.map_partitions`](https://docs.dask.org/en/stable/generated/dask.dataframe.DataFrame.map_partitions.html) is not a usable alternative because it doesn't provide an API for specifying output shape, and therefore would force us to eagerly compute chunk sizes in order to reshape from the flat sample space back to image space, which kills performance.

### Storing Feature Names on the Array Chunks

If there was a way to patch feature names onto each chunk when the image is fed into `apply_gufunc`, we could theoretically trick `sklearn` into thinking it's a dataframe and run the correct checks, but I couldn't find any way to do this.

### Overriding `_check_feature_names`

`ImageEstimator` already wraps some estimator methods, but wrapping `_check_feature_names` isn't an option because it frequently (always?) gets called from subclasses, e.g. `BaseEstimator.predict`, so the wrapped method wouldn't be used. Rather the wrapping, we could directly override it which would cause it to get called from subclasses due to MRO, but this doesn't work for special cases like our transformed estimators, as we would need to also override the transformer's check method. Given that we have no way of knowing where exactly a check could get called from, I decided this wasn't practical.

## Testing

A lot of our tests in `test_predict.py` were based on parameterizing over the image types and wrapping the image in `dummy_model_data` into that type, but this led to warnings as we would have images with feature names but arrays without them. To solve that I added the `ModelData` class that can generate compatible images and X-y arrays. I thought I might be able to use it to replace `parametrize_image_types` everywhere, which is why I put in some functionality to parameterize over specific image data, but that turned out to be more trouble than it was worth, so at the moment it's a bit over-built for how it's being used. 

I did manage to simplify `parametrize_image_types` a bit by removing the `TestImageType` dataclass, which was responsible for storing image types and preprocessors together, in favor of simply parameterizing over the types and using a new function `get_image_preprocessor` to get the corresponding preprocessor.