### PR TITLE
Fix dataframe indexing for `sknnr` estimators

### DIFF
--- a/src/sknnr_spatial/estimator.py
+++ b/src/sknnr_spatial/estimator.py
@@ -10,13 +10,9 @@ from sklearn.utils.validation import _get_feature_names, check_is_fitted
 from typing_extensions import Literal, overload
 
 from .types import EstimatorType
-from .utils.estimator import (
-    AttrWrapper,
-    check_wrapper_implements,
-    image_or_fallback,
-    is_fitted,
-)
-from .utils.image import get_image_wrapper
+from .utils.estimator import is_fitted
+from .utils.image import get_image_wrapper, image_or_fallback
+from .utils.wrapper import AttrWrapper, check_wrapper_implements
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -115,9 +111,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             # to (n_samples,), which has a consistent output shape.
             y = y.squeeze()
 
-        # Cast X to array before fitting to prevent the estimator from storing feature
-        # names. We implement our own feature name checks that are image-compatible.
-        self._wrapped = self._wrapped.fit(np.asarray(X), y, **kwargs)
+        self._wrapped = self._wrapped.fit(X, y, **kwargs)
         fitted_feature_names = _get_feature_names(X)
 
         self._wrapped_meta = FittedMetadata(

--- a/src/sknnr_spatial/utils/estimator.py
+++ b/src/sknnr_spatial/utils/estimator.py
@@ -1,67 +1,7 @@
-from functools import wraps
-from typing import Callable, Generic
+import warnings
 
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import NotFittedError, check_is_fitted
-from typing_extensions import Concatenate, ParamSpec, TypeVar
-
-from ..image._base import ImageType
-from ..types import AnyType
-from .image import is_image_type
-
-RT = TypeVar("RT")
-P = ParamSpec("P")
-
-
-class AttrWrapper(Generic[AnyType]):
-    """A transparent object wrapper that accesses a wrapped object's attributes."""
-
-    _wrapped: AnyType
-
-    def __init__(self, wrapped: AnyType):
-        self._wrapped = wrapped
-
-    def __getattr__(self, name: str):
-        return getattr(self._wrapped, name)
-
-    @property
-    def __dict__(self):
-        return self._wrapped.__dict__
-
-
-GenericWrapper = TypeVar("GenericWrapper", bound=AttrWrapper)
-
-
-def check_wrapper_implements(
-    func: Callable[Concatenate[GenericWrapper, P], RT],
-) -> Callable[Concatenate[GenericWrapper, P], RT]:
-    """Decorator that raises if the wrapped instance doesn't implement the method."""
-
-    @wraps(func)
-    def wrapper(self: GenericWrapper, *args, **kwargs):
-        if not hasattr(self._wrapped, func.__name__):
-            wrapped_class = self._wrapped.__class__.__name__
-            msg = f"{wrapped_class} does not implement {func.__name__}."
-            raise NotImplementedError(msg)
-
-        return func(self, *args, **kwargs)
-
-    return wrapper
-
-
-def image_or_fallback(
-    func: Callable[Concatenate[GenericWrapper, ImageType, P], RT],
-) -> Callable[Concatenate[GenericWrapper, ImageType, P], RT]:
-    """Decorator that calls the wrapped method for non-image X arrays."""
-
-    @wraps(func)
-    def wrapper(self: GenericWrapper, X_image: ImageType, *args, **kwargs):
-        if not is_image_type(X_image):
-            return getattr(self._wrapped, func.__name__)(X_image, *args, **kwargs)
-
-        return func(self, X_image, *args, **kwargs)
-
-    return wrapper
 
 
 def is_fitted(estimator: BaseEstimator) -> bool:
@@ -71,3 +11,15 @@ def is_fitted(estimator: BaseEstimator) -> bool:
         return True
     except NotFittedError:
         return False
+
+
+def suppress_feature_name_warnings(func):
+    """Suppress warnings related to missing feature names in a wrapped function."""
+    msg = "X does not have valid feature names"
+
+    def wrapper(*args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=msg)
+            return func(*args, **kwargs)
+
+    return wrapper

--- a/src/sknnr_spatial/utils/image.py
+++ b/src/sknnr_spatial/utils/image.py
@@ -1,11 +1,18 @@
+from functools import wraps
+from typing import Callable
+
 import numpy as np
 import xarray as xr
-from typing_extensions import Any
+from typing_extensions import Any, Concatenate, ParamSpec, TypeVar
 
 from ..image._base import ImagePreprocessor, ImageType, ImageWrapper
 from ..image.dataarray import DataArrayWrapper
 from ..image.dataset import DatasetWrapper
 from ..image.ndarray import NDArrayWrapper
+from .wrapper import GenericWrapper
+
+RT = TypeVar("RT")
+P = ParamSpec("P")
 
 
 def is_image_type(X: Any) -> bool:
@@ -18,6 +25,21 @@ def is_image_type(X: Any) -> bool:
         return len(X.dims) == 2
 
     return False
+
+
+def image_or_fallback(
+    func: Callable[Concatenate[GenericWrapper, ImageType, P], RT],
+) -> Callable[Concatenate[GenericWrapper, ImageType, P], RT]:
+    """Decorator that calls the wrapped method for non-image X arrays."""
+
+    @wraps(func)
+    def wrapper(self: GenericWrapper, X_image: ImageType, *args, **kwargs):
+        if not is_image_type(X_image):
+            return getattr(self._wrapped, func.__name__)(X_image, *args, **kwargs)
+
+        return func(self, X_image, *args, **kwargs)
+
+    return wrapper
 
 
 def get_image_wrapper(X_image: ImageType) -> type[ImageWrapper]:

--- a/src/sknnr_spatial/utils/wrapper.py
+++ b/src/sknnr_spatial/utils/wrapper.py
@@ -1,0 +1,45 @@
+from functools import wraps
+from typing import Callable, Generic
+
+from typing_extensions import Concatenate, ParamSpec, TypeVar
+
+from ..types import AnyType
+
+RT = TypeVar("RT")
+P = ParamSpec("P")
+
+
+class AttrWrapper(Generic[AnyType]):
+    """A transparent object wrapper that accesses a wrapped object's attributes."""
+
+    _wrapped: AnyType
+
+    def __init__(self, wrapped: AnyType):
+        self._wrapped = wrapped
+
+    def __getattr__(self, name: str):
+        return getattr(self._wrapped, name)
+
+    @property
+    def __dict__(self):
+        return self._wrapped.__dict__
+
+
+GenericWrapper = TypeVar("GenericWrapper", bound=AttrWrapper)
+
+
+def check_wrapper_implements(
+    func: Callable[Concatenate[GenericWrapper, P], RT],
+) -> Callable[Concatenate[GenericWrapper, P], RT]:
+    """Decorator that raises if the wrapped instance doesn't implement the method."""
+
+    @wraps(func)
+    def wrapper(self: GenericWrapper, *args, **kwargs):
+        if not hasattr(self._wrapped, func.__name__):
+            wrapped_class = self._wrapped.__class__.__name__
+            msg = f"{wrapped_class} does not implement {func.__name__}."
+            raise NotImplementedError(msg)
+
+        return func(self, *args, **kwargs)
+
+    return wrapper

--- a/tests/test_sknnr.py
+++ b/tests/test_sknnr.py
@@ -1,0 +1,40 @@
+import numpy as np
+import xarray as xr
+from sknnr import GNNRegressor
+
+from sknnr_spatial import wrap
+
+from .image_utils import parametrize_model_data
+
+
+@parametrize_model_data(image_types=(xr.DataArray,))
+def test_kneighbors_returns_df_index(model_data):
+    """Test that sknnr estimators return dataframe indices."""
+    # Create dummy plot data
+    X = np.random.rand(10, 3) + 10.0
+    y = np.random.rand(10, 3)
+
+    # Create an image of zeros and set the first plot to zeros to ensure that the
+    # first index is the nearest neighbor to all pixels
+    X_image = np.zeros((2, 2, 3))
+    X[0] = [0, 0, 0]
+
+    # Convert model data to the correct types
+    X_image, X, y = model_data.set(
+        X_image=X_image,
+        X=X,
+        y=y,
+    )
+
+    # Offset the dataframe index to differentiate it from the array index
+    df_index_offset = 999
+    X.index += df_index_offset
+
+    est = wrap(GNNRegressor()).fit(X, y)
+    idx = est.kneighbors(X_image, return_distance=False, return_dataframe_index=False)
+    df_idx = est.kneighbors(X_image, return_distance=False, return_dataframe_index=True)
+
+    assert idx.shape == df_idx.shape
+
+    assert idx.min().compute() == 0
+    assert df_idx.min().compute() == df_index_offset

--- a/tests/test_sknnr.py
+++ b/tests/test_sknnr.py
@@ -36,5 +36,6 @@ def test_kneighbors_returns_df_index(model_data):
 
     assert idx.shape == df_idx.shape
 
-    assert idx.min().compute() == 0
-    assert df_idx.min().compute() == df_index_offset
+    # The first neighbor should be the first index for all pixels
+    assert (idx.sel(variable="k1") == 0).all().compute()
+    assert (df_idx.sel(variable="k1") == df_index_offset).all().compute()


### PR DESCRIPTION
This closes #25 and HOPEFULLY solves feature name warnings for the last time.

The previous fix for feature name warnings (#23) was to prevent fitting wrapped estimators with dataframe data, but this had an unintended side effect of breaking any functionality that depended on fitting with dataframes, like returning dataframe indexes in sknnr estimators.

I removed the array conversion to restore dataframe indexing, and added a function `suppress_feature_name_warnings` that suppresses missing feature name warnings in wrapped functions. By wrapping the functions applied by `apply_gufunc` (e.g. `predict` and `kneighbors`), we can suppress the warning when it arises at compute time, rather than during the eager call to `apply_gufunc`. We'll need to use that function any time that `sklearn` runs feature name checks on chunked arrays (e.g. `transform` in #16), so it may be worth abstracting some of that repeated code out eventually.

I also shuffled the `utils` modules around to avoid some circular dependency issues. I didn't put a ton of thought into this, so there might be a better way to organize things.