### PR TITLE
Switch `NDArrayImage` dimension order to `(band, y, x)`

### DIFF
--- a/src/sknnr_spatial/datasets/_base.py
+++ b/src/sknnr_spatial/datasets/_base.py
@@ -52,15 +52,15 @@ def _load_rasters_to_dataset(
 
 
 def _load_rasters_to_array(file_paths: list[Path]) -> NDArray:
-    """Load a list of rasters as a numpy array."""
+    """Load single-band rasters as a multi-band numpy array of shape (band, y, x)."""
     arr = None
-    for i, path in enumerate(file_paths):
+    for path in file_paths:
         with rasterio.open(path) as src:
             band = src.read(1)
-            if arr is None:
-                arr = np.empty((len(file_paths), *band.shape), dtype=band.dtype)
+            # Add a band dimension to the array to allow concatenation
+            band = band[np.newaxis, ...]
 
-            arr[i] = band
+            arr = band if arr is None else np.concatenate((arr, band), axis=0)
 
     return arr
 

--- a/src/sknnr_spatial/datasets/_base.py
+++ b/src/sknnr_spatial/datasets/_base.py
@@ -54,10 +54,13 @@ def _load_rasters_to_dataset(
 def _load_rasters_to_array(file_paths: list[Path]) -> NDArray:
     """Load a list of rasters as a numpy array."""
     arr = None
-    for path in file_paths:
+    for i, path in enumerate(file_paths):
         with rasterio.open(path) as src:
             band = src.read(1)
-            arr = band if arr is None else np.dstack((arr, band))
+            if arr is None:
+                arr = np.empty((len(file_paths), *band.shape), dtype=band.dtype)
+
+            arr[i] = band
 
     return arr
 
@@ -103,7 +106,8 @@ def load_swo_ecoplot(
     Parameters
     ----------
     as_dataset : bool, default=False
-        If True, return the image data as an `xarray.Dataset` instead of a Numpy array.
+        If True, return the image data as an `xarray.Dataset`. Otherwise, return a
+        Numpy array of shape (bands, y, x).
     large_rasters : bool, default=False
         If True, load the 2048x4096 version of the image data. Otherwise, load the
         128x128 version.
@@ -115,8 +119,8 @@ def load_swo_ecoplot(
     Returns
     -------
     tuple
-        Image data as either a numpy array or `xarray.Dataset`, and plot data as X and
-        y dataframes.
+        Image data as either a numpy array of shape (bands, y, x) or `xarray.Dataset`,
+        and plot data as X and y dataframes.
 
     Notes
     -----
@@ -135,7 +139,7 @@ def load_swo_ecoplot(
     >>> from sknnr_spatial.datasets import load_swo_ecoplot
     >>> X_image, X, y = load_swo_ecoplot()
     >>> print(X_image.shape)
-    (128, 128, 18)
+    (18, 128, 128)
 
     Load the 2048x4096 image data as an xarray Dataset:
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -64,7 +64,7 @@ def test_load_dataset(configuration: DatasetConfiguration, as_dataset: bool):
             "x": configuration.image_size[1],
         }
     else:
-        assert X_image.shape == (*configuration.image_size, configuration.n_features)
+        assert X_image.shape == (configuration.n_features, *configuration.image_size)
 
 
 def test_load_dataset_with_chunks():

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -31,9 +31,9 @@ def test_predict(model_data: ModelData, estimator, single_output, squeeze):
 
     assert y_pred.ndim == 3
     expected_shape = (
+        1 if single_output else model_data.n_targets,
         model_data.n_rows,
         model_data.n_cols,
-        1 if single_output else model_data.n_targets,
     )
     assert_array_equal(y_pred.shape, expected_shape)
 
@@ -49,7 +49,7 @@ def test_predict_unsupervised(model_data: ModelData, estimator):
     y_pred = unwrap_image(estimator.predict(X_image))
 
     assert y_pred.ndim == 3
-    expected_shape = (model_data.n_rows, model_data.n_cols, 1)
+    expected_shape = (1, model_data.n_rows, model_data.n_cols)
     assert_array_equal(y_pred.shape, expected_shape)
 
 
@@ -68,8 +68,8 @@ def test_kneighbors_with_distance(model_data: ModelData, k):
     assert dist.ndim == 3
     assert nn.ndim == 3
 
-    assert_array_equal(dist.shape, (model_data.n_rows, model_data.n_cols, k))
-    assert_array_equal(nn.shape, (model_data.n_rows, model_data.n_cols, k))
+    assert_array_equal(dist.shape, (k, model_data.n_rows, model_data.n_cols))
+    assert_array_equal(nn.shape, (k, model_data.n_rows, model_data.n_cols))
 
 
 @parametrize_model_data()
@@ -84,7 +84,7 @@ def test_kneighbors_without_distance(model_data: ModelData, k):
 
     assert nn.ndim == 3
 
-    assert_array_equal(nn.shape, (model_data.n_rows, model_data.n_cols, k))
+    assert_array_equal(nn.shape, (k, model_data.n_rows, model_data.n_cols))
 
 
 @parametrize_model_data()
@@ -100,7 +100,7 @@ def test_kneighbors_with_n_neighbors(model_data: ModelData, n_neighbors):
 
     assert nn.ndim == 3
 
-    assert_array_equal(nn.shape, (model_data.n_rows, model_data.n_cols, n_neighbors))
+    assert_array_equal(nn.shape, (n_neighbors, model_data.n_rows, model_data.n_cols))
 
 
 @parametrize_model_data()
@@ -118,8 +118,8 @@ def test_kneighbors_unsupervised(model_data: ModelData, k):
     assert dist.ndim == 3
     assert nn.ndim == 3
 
-    assert_array_equal(dist.shape, (model_data.n_rows, model_data.n_cols, k))
-    assert_array_equal(nn.shape, (model_data.n_rows, model_data.n_cols, k))
+    assert_array_equal(dist.shape, (k, model_data.n_rows, model_data.n_cols))
+    assert_array_equal(nn.shape, (k, model_data.n_rows, model_data.n_cols))
 
 
 @parametrize_model_data(image_types=(xr.DataArray,))
@@ -133,7 +133,7 @@ def test_predict_dataarray_with_custom_dim_name(model_data: ModelData):
     y_pred = unwrap_image(estimator.predict(X_image))
     assert y_pred.ndim == 3
     assert_array_equal(
-        y_pred.shape, (model_data.n_rows, model_data.n_cols, model_data.n_targets)
+        y_pred.shape, (model_data.n_targets, model_data.n_rows, model_data.n_cols)
     )
 
 

--- a/tests/test_sknnr.py
+++ b/tests/test_sknnr.py
@@ -18,7 +18,7 @@ def test_kneighbors_returns_df_index(model_data):
 
     # Create an image of zeros and set the first plot to zeros to ensure that the
     # first index is the nearest neighbor to all pixels
-    X_image = np.zeros((2, 2, 3))
+    X_image = np.zeros((3, 2, 2))
     X[0] = [0, 0, 0]
 
     # Convert model data to the correct types


### PR DESCRIPTION
Closes #29 by making `NDArrayImage` use shape `(band, y, x)`, which is consistent with multi-band images loaded by `rasterio` or `rioxarray`. Dataset loading and tests were updated to work with the new dimension order.

It's worth noting that internally, `_ImageChunk` still handles images in `(y, x, band)` order because `xr.apply_ufunc` always moves the core dimension (band) to the last axis. This means that `NDArrayImage` also has to transpose arrays before they go into the ufunc, and both image types need to transpose the ufunc outputs back to `(band, y, x)`.

To reduce some duplication introduced by that change, I refactored `apply_ufunc_across_bands` from the `Image` subclasses into the base class, with the type-specific functionality now handled by preprocessing and postprocessing functions. This means that both image types are now handled identically by `xr.apply_ufunc`, which further simplifies things. It does feel a little weird calling `xr.apply_ufunc` with Numpy arrays, but it's a documented feature and I'm sure the overhead of passing it through is negligible. 